### PR TITLE
Add Linux container developer environment

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -1,6 +1,14 @@
 [envs.default]
 installer = "uv"
 
+[envs.hatch-static-analysis]
+config-path = "ruff_defaults.toml"
+
+[envs.hatch-test]
+extra-dependencies = [
+  "pyfakefs",
+]
+
 [envs.types]
 extra-dependencies = [
   "mypy",
@@ -8,6 +16,3 @@ extra-dependencies = [
 ]
 [envs.types.scripts]
 check = "mypy --install-types --non-interactive {args:src/deva tests}"
-
-[envs.hatch-static-analysis]
-config-path = "ruff_defaults.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
   "rich~=13.7",
   "rich-click~=1.8",
   "tomlkit~=0.13",
+  # https://peps.python.org/pep-0696/
+  "typing-extensions>=4.6.0; python_version < '3.13'",
 ]
 
 [project.urls]

--- a/src/deva/cli/__init__.py
+++ b/src/deva/cli/__init__.py
@@ -13,7 +13,7 @@ from deva.config.constants import AppEnvVars, ConfigEnvVars
 
 
 @dynamic_group(
-    context_settings={"help_option_names": ["-h", "--help"], "max_content_width": 120},
+    context_settings={"help_option_names": ["-h", "--help"], "max_content_width": 120, "show_default": True},
     invoke_without_command=True,
     external_plugins=True,
     subcommands=(

--- a/src/deva/cli/base.py
+++ b/src/deva/cli/base.py
@@ -20,6 +20,10 @@ class DynamicContext(click.RichContext):
         # https://github.com/pallets/click/pull/2784
         return []
 
+    def get_dynamic_sibling(self) -> click.RichContext:
+        cmd = DynamicCommand(name=None, params=self.dynamic_params)
+        return cmd.make_context(info_name=None, args=self.args, parent=self)
+
 
 class DynamicCommand(click.RichCommand):
     context_class = DynamicContext

--- a/src/deva/cli/config/set/__init__.py
+++ b/src/deva/cli/config/set/__init__.py
@@ -22,6 +22,7 @@ def cmd(app: Application, key: str, value: str | None) -> None:
     Set the value of config keys. If the value is omitted, you will
     be prompted, with the input hidden if it is sensitive.
     """
+    import json
     from fnmatch import fnmatch
 
     import msgspec
@@ -76,8 +77,11 @@ def cmd(app: Application, key: str, value: str | None) -> None:
 
     branch_config[key] = new_config[key]
 
+    # Reconstruct the config without weird tomlkit objects that mirror built-in types
+    fresh_config = json.loads(json.dumps(user_config))
+
     try:
-        construct_model(dict(user_config))
+        construct_model(fresh_config)
     except msgspec.ValidationError as e:
         app.display_error(str(e))
         app.abort()

--- a/src/deva/cli/env/dev/__init__.py
+++ b/src/deva/cli/env/dev/__init__.py
@@ -9,6 +9,9 @@ from deva.cli.base import dynamic_group
 @dynamic_group(
     short_help="Work with developer environments",
     subcommands=(
+        "code",
+        "gui",
+        "ls",
         "remove",
         "run",
         "shell",

--- a/src/deva/cli/env/dev/code/__init__.py
+++ b/src/deva/cli/env/dev/code/__init__.py
@@ -14,25 +14,15 @@ if TYPE_CHECKING:
     from deva.cli.application import Application
 
 
-@dynamic_command(
-    short_help="Run a command within a developer environment",
-    context_settings={"help_option_names": [], "ignore_unknown_options": True},
-)
-@click.argument("args", required=True, nargs=-1)
+@dynamic_command(short_help="Open a code editor for the developer environment")
 @option_env_type()
 @click.option("--id", "instance", default="default", help="Unique identifier for the environment")
-@click.option("--repo", "-r", help="The Datadog repository in which to run the command")
-@click.pass_context
-def cmd(ctx: click.Context, *, args: tuple[str, ...], env_type: str, instance: str, repo: str | None) -> None:
+@click.option("--repo", "-r", help="The Datadog repository to work on")
+@click.pass_obj
+def cmd(app: Application, *, env_type: str, instance: str, repo: str | None) -> None:
     """
-    Run a command within a developer environment.
+    Open a code editor for the developer environment.
     """
-    app: Application = ctx.obj
-    first_arg = args[0]
-    if first_arg in {"-h", "--help"}:
-        app.display(ctx.get_help())
-        app.abort(code=0)
-
     from deva.env.dev import get_dev_env
     from deva.env.models import EnvironmentState
 
@@ -46,4 +36,4 @@ def cmd(ctx: click.Context, *, args: tuple[str, ...], env_type: str, instance: s
     if status.state != expected_state:
         app.abort(f"Developer environment `{env_type}` is in state `{status.state}`, must be `{expected_state}`")
 
-    env.run_command(list(args), repo=repo)
+    env.code(repo=repo)

--- a/src/deva/cli/env/dev/gui/__init__.py
+++ b/src/deva/cli/env/dev/gui/__init__.py
@@ -14,25 +14,14 @@ if TYPE_CHECKING:
     from deva.cli.application import Application
 
 
-@dynamic_command(
-    short_help="Run a command within a developer environment",
-    context_settings={"help_option_names": [], "ignore_unknown_options": True},
-)
-@click.argument("args", required=True, nargs=-1)
+@dynamic_command(short_help="Access a developer environment through a graphical interface")
 @option_env_type()
 @click.option("--id", "instance", default="default", help="Unique identifier for the environment")
-@click.option("--repo", "-r", help="The Datadog repository in which to run the command")
-@click.pass_context
-def cmd(ctx: click.Context, *, args: tuple[str, ...], env_type: str, instance: str, repo: str | None) -> None:
+@click.pass_obj
+def cmd(app: Application, *, env_type: str, instance: str) -> None:
     """
-    Run a command within a developer environment.
+    Access a developer environment through a graphical interface.
     """
-    app: Application = ctx.obj
-    first_arg = args[0]
-    if first_arg in {"-h", "--help"}:
-        app.display(ctx.get_help())
-        app.abort(code=0)
-
     from deva.env.dev import get_dev_env
     from deva.env.models import EnvironmentState
 
@@ -46,4 +35,7 @@ def cmd(ctx: click.Context, *, args: tuple[str, ...], env_type: str, instance: s
     if status.state != expected_state:
         app.abort(f"Developer environment `{env_type}` is in state `{status.state}`, must be `{expected_state}`")
 
-    env.run_command(list(args), repo=repo)
+    try:
+        env.launch_gui()
+    except NotImplementedError:
+        app.abort(f"Developer environment type does not support GUI access: {env_type}")

--- a/src/deva/cli/env/dev/ls/__init__.py
+++ b/src/deva/cli/env/dev/ls/__init__.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from deva.cli.base import dynamic_command
+
+if TYPE_CHECKING:
+    from deva.cli.application import Application
+
+
+@dynamic_command(short_help="List the available developer environments")
+@click.pass_obj
+def cmd(app: Application) -> None:
+    """
+    List the available developer environments.
+    """
+    import json
+
+    from deva.env.dev import get_dev_env
+
+    env_data = {}
+    storage_dirs = app.config.storage.join("env", "dev")
+    for env_type in sorted(storage_dirs.data.iterdir()):
+        type_name = env_type.name
+        instance_data = {}
+        for instance in sorted(env_type.iterdir()):
+            instance_name = instance.name
+            env = get_dev_env(type_name)(
+                app=app,
+                name=type_name,
+                instance=instance_name,
+            )
+            if env.config_file.is_file():
+                env_status = env.status()
+                instance_data[instance_name] = {
+                    "State": env_status.state,
+                    "Config": json.loads(env.config_file.read_text()),
+                }
+
+        if instance_data:
+            env_data[type_name] = instance_data
+
+    if not env_data:
+        app.display("No developer environments found")
+        return
+
+    app.display_table(env_data)

--- a/src/deva/cli/env/dev/shell/__init__.py
+++ b/src/deva/cli/env/dev/shell/__init__.py
@@ -14,18 +14,26 @@ if TYPE_CHECKING:
     from deva.cli.application import Application
 
 
-@dynamic_command(short_help="Enter a developer environment")
+@dynamic_command(short_help="Spawn a shell within a developer environment")
 @option_env_type()
+@click.option("--id", "instance", default="default", help="Unique identifier for the environment")
+@click.option("--repo", "-r", help="The Datadog repository in which to enter")
 @click.pass_obj
-def cmd(app: Application, env_type: str) -> None:
+def cmd(app: Application, *, env_type: str, instance: str, repo: str | None) -> None:
     """
-    Enter a developer environment.
+    Spawn a shell within a developer environment.
     """
     from deva.env.dev import get_dev_env
+    from deva.env.models import EnvironmentState
 
     env = get_dev_env(env_type)(
         app=app,
         name=env_type,
+        instance=instance,
     )
-    # Elide a status check and attempt to enter directly in order to improve responsiveness
-    env.shell()
+    status = env.status()
+    expected_state = EnvironmentState.STARTED
+    if status.state != expected_state:
+        app.abort(f"Developer environment `{env_type}` is in state `{status.state}`, must be `{expected_state}`")
+
+    env.launch_shell(repo=repo)

--- a/src/deva/cli/env/dev/start/__init__.py
+++ b/src/deva/cli/env/dev/start/__init__.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import click
 
@@ -16,49 +16,64 @@ if TYPE_CHECKING:
     from deva.cli.base import DynamicContext
 
 
-def resolve_environment(ctx: DynamicContext, param: click.Option, value: str) -> str:  # noqa: ARG001
+def resolve_environment(ctx: DynamicContext, param: click.Option, value: str) -> str:
     from msgspec_click import generate_options
 
-    env_type = get_env_type(value, ctx)
+    env_type = get_env_type(ctx, param, value)
     env_class = get_dev_env(env_type)
     ctx.dynamic_params.extend(generate_options(env_class.config_class()))
     return env_type
 
 
-@dynamic_command(short_help="Start a developer environment", context_settings={"ignore_unknown_options": True})
+@dynamic_command(
+    short_help="Start a developer environment",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
+)
 @option_env_type(callback=resolve_environment)
+@click.option("--id", "instance", default="default", help="Unique identifier for the environment")
 @click.pass_context
-def cmd(ctx: click.Context, env_type: str, **kwargs: Any) -> None:
+def cmd(ctx: click.Context, *, env_type: str, instance: str) -> None:
     """
     Start a developer environment.
     """
     import msgspec
 
-    from deva.env.models import EnvironmentStage
+    from deva.env.models import EnvironmentState
 
     app: Application = ctx.obj
+
+    dynamic_context = ctx.get_dynamic_sibling()  # type: ignore[attr-defined]
+    dynamic_options = {
+        param: value
+        for param, value in dynamic_context.params.items()
+        if dynamic_context.get_parameter_source(param).name != "DEFAULT"
+    }
     user_config = dict(app.config.envs.get(env_type, {}))
-    user_config.update(kwargs)
+    user_config.update(dynamic_options)
+    if "shell" not in user_config and app.config.env.dev.universal_shell:
+        user_config["shell"] = "nu"
 
     env_class = get_dev_env(env_type)
     config = msgspec.convert(user_config, env_class.config_class())
     env = env_class(
         app=app,
         name=env_type,
+        instance=instance,
         config=config,
     )
-    if kwargs and env.config_file.is_file():
-        options = ", ".join(sorted(kwargs))
+    if dynamic_options and env.config_file.is_file():
+        options = ", ".join(sorted(dynamic_options))
         app.abort(
             f"Ignoring the following options as environments cannot be reconfigured from a stopped state: {options}\n"
             f"To change the configuration, you must remove the environment after stopping it."
         )
 
     status = env.status()
-    expected_stage = EnvironmentStage.INACTIVE
-    if status.stage != expected_stage:
+    transition_states = {EnvironmentState.NONEXISTENT, EnvironmentState.STOPPED}
+    if status.state not in transition_states:
         app.abort(
-            f"Cannot start developer environment `{env_type}` in stage `{status.stage}`, must be `{expected_stage}`"
+            f"Cannot start developer environment `{env_type}` in state `{status.state}`, must be one of: "
+            f"{", ".join(sorted(transition_states))}"
         )
 
     env.start()

--- a/src/deva/cli/env/dev/status/__init__.py
+++ b/src/deva/cli/env/dev/status/__init__.py
@@ -16,8 +16,9 @@ if TYPE_CHECKING:
 
 @dynamic_command(short_help="Check the status of a developer environment")
 @option_env_type()
+@click.option("--id", "instance", default="default", help="Unique identifier for the environment")
 @click.pass_obj
-def cmd(app: Application, env_type: str) -> None:
+def cmd(app: Application, *, env_type: str, instance: str) -> None:
     """
     Check the status of a developer environment.
     """
@@ -26,8 +27,9 @@ def cmd(app: Application, env_type: str) -> None:
     env = get_dev_env(env_type)(
         app=app,
         name=env_type,
+        instance=instance,
     )
     status = env.status()
-    app.display(f"Stage: {status.stage.value}")
+    app.display(f"State: {status.state.value}")
     if status.info:
         app.display(status.info)

--- a/src/deva/cli/env/dev/stop/__init__.py
+++ b/src/deva/cli/env/dev/stop/__init__.py
@@ -16,23 +16,29 @@ if TYPE_CHECKING:
 
 @dynamic_command(short_help="Stop a developer environment")
 @option_env_type()
+@click.option("--id", "instance", default="default", help="Unique identifier for the environment")
+@click.option("-r", "--remove", is_flag=True, help="Remove the environment after stopping")
 @click.pass_obj
-def cmd(app: Application, env_type: str) -> None:
+def cmd(app: Application, *, env_type: str, instance: str, remove: bool) -> None:
     """
     Stop a developer environment.
     """
     from deva.env.dev import get_dev_env
-    from deva.env.models import EnvironmentStage
+    from deva.env.models import EnvironmentState
 
     env = get_dev_env(env_type)(
         app=app,
         name=env_type,
+        instance=instance,
     )
     status = env.status()
-    expected_stage = EnvironmentStage.ACTIVE
-    if status.stage != expected_stage:
+    expected_state = EnvironmentState.STARTED
+    if status.state != expected_state:
         app.abort(
-            f"Cannot stop developer environment `{env_type}` in stage `{status.stage}`, must be `{expected_stage}`"
+            f"Cannot stop developer environment `{env_type}` in state `{status.state}`, must be `{expected_state}`"
         )
 
-    env.remove_config()
+    env.stop()
+    if remove:
+        env.remove()
+        env.remove_config()

--- a/src/deva/cli/env/dev/utils.py
+++ b/src/deva/cli/env/dev/utils.py
@@ -14,18 +14,20 @@ if TYPE_CHECKING:
     from deva.cli.application import Application
 
 
-def get_env_type(value: str | None, ctx: click.Context) -> str:
+def get_env_type(ctx: click.Context, param: click.Option, value: str | None) -> str:
     if value:
         return value
 
     app: Application = ctx.obj
-    return app.config.env.dev.default_type or DEFAULT_DEV_ENV
+    env_type = app.config.env.dev.default_type or DEFAULT_DEV_ENV
+    param.default = env_type
+    return env_type
 
 
-def option_env_type_callback(ctx: click.Context, param: click.Option, value: str | None) -> str:  # noqa: ARG001
+def option_env_type_callback(ctx: click.Context, param: click.Option, value: str | None) -> str:
     from deva.cli.env.dev.utils import get_env_type
 
-    return get_env_type(value, ctx)
+    return get_env_type(ctx, param, value)
 
 
 option_env_type = partial(

--- a/src/deva/config/model/__init__.py
+++ b/src/deva/config/model/__init__.py
@@ -8,6 +8,7 @@ from typing import Any
 from msgspec import Struct, convert, field, to_builtins
 
 from deva.config.model.env import EnvConfig
+from deva.config.model.git import GitConfig
 from deva.config.model.github import GitHubConfig
 from deva.config.model.orgs import OrgConfig
 from deva.config.model.storage import StorageDirs
@@ -24,6 +25,7 @@ class RootConfig(Struct, frozen=True, omit_defaults=True):
     env: EnvConfig = field(default_factory=EnvConfig)
     envs: dict[str, dict[str, Any]] = {}
     storage: StorageDirs = field(default_factory=StorageDirs)
+    git: GitConfig = field(default_factory=GitConfig)
     github: GitHubConfig = field(default_factory=GitHubConfig)
     terminal: TerminalConfig = field(default_factory=TerminalConfig)
 

--- a/src/deva/config/model/env.py
+++ b/src/deva/config/model/env.py
@@ -10,6 +10,7 @@ from deva.env.dev import DEFAULT_DEV_ENV
 
 class DevEnvConfig(Struct, frozen=True):
     default_type: str = field(name="default-type", default=DEFAULT_DEV_ENV)
+    universal_shell: bool = field(name="universal-shell", default=False)
 
 
 class EnvConfig(Struct, frozen=True):

--- a/src/deva/config/model/git.py
+++ b/src/deva/config/model/git.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from msgspec import Struct, field
+
+
+def _get_config(env_var: str, config_name: str) -> str:
+    import os
+
+    value = os.environ.get(env_var, "")
+    if value:
+        return value
+
+    import subprocess
+
+    try:
+        return subprocess.run(
+            ["git", "config", "--global", "--get", config_name],  # noqa: S607
+            encoding="utf-8",
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def default_user_name() -> str:
+    return _get_config("GIT_AUTHOR_NAME", "user.name")
+
+
+def default_user_email() -> str:
+    return _get_config("GIT_AUTHOR_EMAIL", "user.email")
+
+
+class GitUser(Struct, frozen=True):
+    name: str = field(default_factory=default_user_name)
+    email: str = field(default_factory=default_user_email)
+
+
+class GitConfig(Struct, frozen=True):
+    user: GitUser = field(default_factory=GitUser)

--- a/src/deva/env/dev/__init__.py
+++ b/src/deva/env/dev/__init__.py
@@ -4,12 +4,13 @@
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
     from deva.env.dev.interface import DeveloperEnvironmentInterface
+    from deva.env.dev.types.linux_container import LinuxContainer
 
 
 DEFAULT_DEV_ENV = "windows-container" if sys.platform == "win32" else "linux-container"
@@ -32,23 +33,25 @@ def __get_windows_cloud() -> type[DeveloperEnvironmentInterface]:
     raise NotImplementedError
 
 
-def __get_linux_container() -> type[DeveloperEnvironmentInterface]:
-    raise NotImplementedError
+def __get_linux_container() -> type[LinuxContainer]:
+    from deva.env.dev.types.linux_container import LinuxContainer
+
+    return LinuxContainer
 
 
 if sys.platform == "win32":
-    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface]]] = {
+    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface[Any]]]] = {
         "windows-container": __get_windows_container,
         "windows-cloud": __get_windows_cloud,
         "linux-container": __get_linux_container,
     }
 elif sys.platform == "darwin":
-    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface]]] = {
+    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface[Any]]]] = {
         "linux-container": __get_linux_container,
         "windows-cloud": __get_windows_cloud,
     }
 else:
-    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface]]] = {
+    __DEV_ENVS: dict[str, Callable[[], type[DeveloperEnvironmentInterface[Any]]]] = {
         "linux-container": __get_linux_container,
         "windows-cloud": __get_windows_cloud,
     }

--- a/src/deva/env/dev/interface.py
+++ b/src/deva/env/dev/interface.py
@@ -5,29 +5,48 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, NoReturn
+from typing import TYPE_CHECKING, Annotated, Generic, NoReturn, cast
 
 import msgspec
 
+
+class DeveloperEnvironmentConfig(msgspec.Struct, kw_only=True):
+    repos: Annotated[
+        list[str],
+        msgspec.Meta(
+            extra={
+                "params": ["-r", "--repo"],
+                "help": (
+                    """\
+The Datadog repositories to work on, optionally with a particular branch or tag. This option may be
+supplied multiple times. Examples:
+
+- `datadog-agent` (default)
+- `datadog-agent@user/test`
+- `integrations-core@X.Y.Z`
+"""
+                ),
+            }
+        ),
+    ] = msgspec.field(default_factory=lambda: ["datadog-agent"])
+
+
 if TYPE_CHECKING:
+    from typing_extensions import TypeVar
+
     from deva.cli.application import Application
     from deva.config.model.storage import StorageDirs
     from deva.env.models import EnvironmentStatus
     from deva.utils.fs import Path
 
+    ConfigT = TypeVar("ConfigT", bound=DeveloperEnvironmentConfig, default=DeveloperEnvironmentConfig)
+else:
+    from typing import TypeVar
 
-class DeveloperEnvironmentConfig(msgspec.Struct, kw_only=True):
-    ref: Annotated[
-        str,
-        msgspec.Meta(
-            extra={
-                "help": "The Git reference for the `datadog-agent` repository",
-            }
-        ),
-    ] = "main"
+    ConfigT = TypeVar("ConfigT")
 
 
-class DeveloperEnvironmentInterface(ABC):
+class DeveloperEnvironmentInterface(ABC, Generic[ConfigT]):
     """
     This interface defines the behavior of a developer environment.
     """
@@ -37,10 +56,12 @@ class DeveloperEnvironmentInterface(ABC):
         *,
         app: Application,
         name: str,
-        config: DeveloperEnvironmentConfig | None = None,
+        instance: str,
+        config: ConfigT | None = None,
     ) -> None:
         self.__app = app
         self.__name = name
+        self.__instance = instance
         self.__config = config
 
     @abstractmethod
@@ -49,7 +70,7 @@ class DeveloperEnvironmentInterface(ABC):
         This method starts the developer environment. If this method returns early, the `status`
         method should contain information about the startup progress.
 
-        This method will never be called if the environment is already running.
+        This method will only be called if the environment is stopped or nonexistent.
         """
 
     @abstractmethod
@@ -57,13 +78,16 @@ class DeveloperEnvironmentInterface(ABC):
         """
         This method stops the developer environment. If this method returns early, the `status`
         method should contain information about the shutdown progress.
+
+        This method will only be called if the environment is started.
         """
 
     @abstractmethod
     def remove(self) -> None:
         """
-        This method removes the developer environment and all associated state. This will never be
-        called if the `status` method indicates that the environment is not `inactive`.
+        This method removes the developer environment and all associated state.
+
+        This method will only be called if the environment is stopped or in an error state.
         """
 
     @abstractmethod
@@ -73,16 +97,28 @@ class DeveloperEnvironmentInterface(ABC):
         """
 
     @abstractmethod
-    def shell(self) -> NoReturn:
+    def code(self, *, repo: str | None = None) -> None:
+        """
+        This method opens the developer environment's code in the configured editor.
+        """
+
+    @abstractmethod
+    def run_command(self, command: list[str], *, repo: str | None = None) -> None:
+        """
+        This method runs a command inside the developer environment.
+        """
+
+    @abstractmethod
+    def launch_shell(self, *, repo: str | None = None) -> NoReturn:
         """
         This method starts an interactive shell inside the developer environment.
         """
 
-    @abstractmethod
-    def run_command(self, command: list[str]) -> None:
+    def launch_gui(self) -> NoReturn:
         """
-        This method runs a command inside the developer environment.
+        This method starts an interactive GUI inside the developer environment using e.g. RDP or VNC.
         """
+        raise NotImplementedError
 
     @property
     def app(self) -> Application:
@@ -92,12 +128,16 @@ class DeveloperEnvironmentInterface(ABC):
     def name(self) -> str:
         return self.__name
 
-    @cached_property
-    def storage_dirs(self) -> StorageDirs:
-        return self.app.config.storage.join("env", "dev", self.__name)
+    @property
+    def instance(self) -> str:
+        return self.__instance
 
     @cached_property
-    def config(self) -> DeveloperEnvironmentConfig:
+    def storage_dirs(self) -> StorageDirs:
+        return self.app.config.storage.join("env", "dev", self.name, self.instance)
+
+    @cached_property
+    def config(self) -> ConfigT:
         return self.__load_config() if self.__config is None else self.__config
 
     @classmethod
@@ -108,14 +148,30 @@ class DeveloperEnvironmentInterface(ABC):
     def config_file(self) -> Path:
         return self.storage_dirs.data.joinpath("config.json")
 
+    @cached_property
+    def shared_dir(self) -> Path:
+        return self.storage_dirs.data.joinpath(".shared")
+
+    @cached_property
+    def global_shared_dir(self) -> Path:
+        return self.storage_dirs.data.parent.joinpath(".shared")
+
+    @cached_property
+    def default_repo(self) -> str:
+        return self.config.repos[0].split("@")[0]
+
     def save_config(self) -> None:
+        self.config_file.parent.ensure_dir()
         self.config_file.write_bytes(msgspec.json.encode(self.config))
 
     def remove_config(self) -> None:
-        self.config_file.unlink()
+        if self.config_file.is_file():
+            self.config_file.unlink()
 
-    def __load_config(self) -> DeveloperEnvironmentConfig:
-        if not self.config_file.exists():
-            return self.config_class()()
-
-        return msgspec.json.decode(self.config_file.read_bytes(), type=self.config_class())
+    def __load_config(self) -> ConfigT:
+        config = (
+            msgspec.json.decode(self.config_file.read_bytes(), type=self.config_class())
+            if self.config_file.is_file()
+            else self.config_class()()
+        )
+        return cast(ConfigT, config)

--- a/src/deva/env/dev/types/__init__.py
+++ b/src/deva/env/dev/types/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/src/deva/env/dev/types/linux_container.py
+++ b/src/deva/env/dev/types/linux_container.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn
+
+import msgspec  # noqa: TCH002
+
+from deva.env.dev.interface import DeveloperEnvironmentConfig, DeveloperEnvironmentInterface
+
+if TYPE_CHECKING:
+    from deva.env.models import EnvironmentStatus
+    from deva.env.shells.interface import Shell
+
+
+class LinuxContainerConfig(DeveloperEnvironmentConfig):
+    image: Annotated[
+        str,
+        msgspec.Meta(
+            extra={
+                "help": "The container image to use",
+            }
+        ),
+    ] = "datadog/agent-dev-env-linux"
+    no_pull: Annotated[
+        bool,
+        msgspec.Meta(
+            extra={
+                "help": "Prevent pulling the image before every container creation",
+            }
+        ),
+    ] = False
+    cli: Annotated[
+        str,
+        msgspec.Meta(
+            extra={
+                "help": "The name or absolute path of the container manager e.g. `docker` or `podman`",
+            }
+        ),
+    ] = "docker"
+    shell: Annotated[
+        Literal["bash", "nu", "zsh"],
+        msgspec.Meta(
+            extra={
+                "help": "The name of the shell to use e.g. `zsh` or `nu`",
+            }
+        ),
+    ] = "zsh"
+
+
+class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.__latest_status: EnvironmentStatus | None = None
+
+    @classmethod
+    def config_class(cls) -> type[LinuxContainerConfig]:
+        return LinuxContainerConfig
+
+    def start(self) -> None:
+        from deva.env.models import EnvironmentState
+
+        status = self.__latest_status if self.__latest_status is not None else self.status()
+        if status.state == EnvironmentState.STOPPED:
+            self.app.subprocess.wait(
+                [self.config.cli, "start", self.container_name], message=f"Starting container: {self.container_name}"
+            )
+        else:
+            from deva.utils.retry import wait_for
+
+            if not self.config.no_pull:
+                self.app.subprocess.wait(
+                    [self.config.cli, "pull", self.config.image], message=f"Pulling image: {self.config.image}"
+                )
+
+            self.shared_dir.ensure_dir()
+            command = [
+                self.config.cli,
+                "run",
+                "--pull",
+                "never",
+                "-d",
+                "--name",
+                self.container_name,
+                "-p",
+                f"{self.ssh_port}:22",
+                "-e",
+                f"DD_SHELL={self.config.shell}",
+            ]
+            for shared_shell_file in self.shell.collect_shared_files():
+                unix_path = shared_shell_file.relative_to(self.global_shared_dir).as_posix()
+                command.extend(("-v", f"{shared_shell_file}:{self.home_dir}/.shared/{unix_path}"))
+
+            command.append(self.config.image)
+            self.app.subprocess.wait(command, message=f"Creating and starting container: {self.container_name}")
+
+            with self.app.status(self.app.style_waiting(f"Waiting for container: {self.container_name}")):
+                wait_for(self.check_readiness, timeout=30, wait=0.3)
+
+            self.ensure_ssh_config()
+
+            for repo_spec in self.config.repos:
+                repo, _, ref = repo_spec.partition("@")
+                if ref:
+                    clone_command = ["git", "dd-clone", repo, ref]
+                    wait_message = f"Cloning repository: {repo}@{ref}"
+                else:
+                    clone_command = ["git", "dd-clone", repo]
+                    wait_message = f"Cloning repository: {repo}"
+
+                self.app.subprocess.wait(self.construct_command(clone_command), message=wait_message)
+
+    def stop(self) -> None:
+        self.app.subprocess.wait(
+            [self.config.cli, "stop", "-t", "0", self.container_name],
+            message=f"Stopping container: {self.container_name}",
+        )
+
+    def remove(self) -> None:
+        self.app.subprocess.wait(
+            [self.config.cli, "rm", "-f", self.container_name], message=f"Removing container: {self.container_name}"
+        )
+
+    def status(self) -> EnvironmentStatus:
+        import json
+
+        from deva.env.models import EnvironmentState, EnvironmentStatus
+
+        output = self.app.subprocess.capture(
+            [self.config.cli, "inspect", self.container_name], check=False, cross_streams=False
+        )
+        items = json.loads(output)
+        if not items:
+            return EnvironmentStatus(state=EnvironmentState.NONEXISTENT)
+
+        inspection = items[0]
+
+        # https://docs.docker.com/reference/api/engine/version/v1.47/#tag/Container/operation/ContainerList
+        # https://docs.podman.io/en/latest/_static/api.html?version=v5.0#tag/containers-(compat)/operation/ContainerList
+        state_data = inspection["State"]
+        status = state_data["Status"].lower()
+        if status == "running":
+            state = EnvironmentState.STARTED
+        elif status in {"created", "paused"}:
+            state = EnvironmentState.STOPPED
+        elif status == "exited":
+            state = EnvironmentState.ERROR if state_data["ExitCode"] == 1 else EnvironmentState.STOPPED
+        elif status == "restarting":
+            state = EnvironmentState.STARTING
+        elif status == "removing":
+            state = EnvironmentState.STOPPING
+        else:
+            state = EnvironmentState.UNKNOWN
+
+        status = EnvironmentStatus(state=state)
+        self.__latest_status = status
+        return status
+
+    def launch_shell(self, *, repo: str | None = None) -> NoReturn:
+        self.ensure_ssh_config()
+        ssh_command = self.ssh_base_command()
+        ssh_command.append(self.shell.get_login_command(cwd=self.repo_path(repo)))
+        self.app.subprocess.replace_current_process(ssh_command)
+
+    def code(self, *, repo: str | None = None) -> None:
+        self.ensure_ssh_config()
+        self.app.subprocess.run(
+            ["code", "--remote", f"ssh-remote+root@localhost:{self.ssh_port}", self.repo_path(repo)],
+        )
+
+    def run_command(self, command: list[str], *, repo: str | None = None) -> None:
+        self.ensure_ssh_config()
+        self.app.subprocess.run(self.construct_command(command, cwd=self.repo_path(repo)))
+
+    @cached_property
+    def hostname(self) -> str:
+        return "localhost"
+
+    @cached_property
+    def ssh_port(self) -> int:
+        from deva.utils.ssh import derive_dynamic_ssh_port
+
+        return derive_dynamic_ssh_port(self.container_name)
+
+    @cached_property
+    def home_dir(self) -> str:
+        return "/root"
+
+    @cached_property
+    def container_name(self) -> str:
+        return f"deva-{self.name}-{self.instance}"
+
+    @cached_property
+    def shell(self) -> Shell:
+        from deva.env.shells import get_shell
+
+        return get_shell(self.config.shell)(self.global_shared_dir)
+
+    def construct_command(self, command: list[str], *, cwd: str | None = None) -> list[str]:
+        if cwd is None:
+            cwd = self.home_dir
+
+        ssh_command = self.ssh_base_command()
+        ssh_command.append(self.shell.format_command(command, cwd=cwd))
+        return ssh_command
+
+    def check_readiness(self) -> bool:
+        output = self.app.subprocess.capture([self.config.cli, "logs", self.container_name])
+        return "Server listening on :: port 22" in output
+
+    def ssh_base_command(self) -> list[str]:
+        from deva.utils.ssh import ssh_base_command
+
+        return ssh_base_command("root@localhost", self.ssh_port)
+
+    def ensure_ssh_config(self) -> None:
+        from deva.env.ssh import ensure_ssh_config
+
+        return ensure_ssh_config(self.hostname)
+
+    def repo_path(self, repo: str | None) -> str:
+        if repo is None:
+            repo = self.default_repo
+
+        return f"{self.home_dir}/repos/{repo}"

--- a/src/deva/env/models.py
+++ b/src/deva/env/models.py
@@ -8,13 +8,16 @@ from enum import StrEnum
 from msgspec import Struct
 
 
-class EnvironmentStage(StrEnum):
-    ACTIVE = "active"
-    INACTIVE = "inactive"
+class EnvironmentState(StrEnum):
+    STARTED = "started"
+    STOPPED = "stopped"
     STARTING = "starting"
     STOPPING = "stopping"
+    ERROR = "error"
+    NONEXISTENT = "nonexistent"
+    UNKNOWN = "unknown"
 
 
 class EnvironmentStatus(Struct, frozen=True, forbid_unknown_fields=True):
-    stage: EnvironmentStage
+    state: EnvironmentState
     info: str = ""

--- a/src/deva/env/shells/__init__.py
+++ b/src/deva/env/shells/__init__.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from deva.env.shells.interface import Shell
+
+
+def get_shell(name: str) -> type[Shell]:
+    shell = __SHELLS.get(name)
+    if shell is None:
+        message = f"Unknown shell: {name}"
+        raise ValueError(message)
+
+    return shell()
+
+
+def __get_bash() -> type[Shell]:
+    from deva.env.shells.bash import BashShell
+
+    return BashShell
+
+
+def __get_zsh() -> type[Shell]:
+    from deva.env.shells.zsh import ZshShell
+
+    return ZshShell
+
+
+def __get_nu() -> type[Shell]:
+    from deva.env.shells.nu import NuShell
+
+    return NuShell
+
+
+__SHELLS: dict[str, Callable[[], type[Shell]]] = {
+    "bash": __get_bash,
+    "nu": __get_nu,
+    "zsh": __get_zsh,
+}

--- a/src/deva/env/shells/bash.py
+++ b/src/deva/env/shells/bash.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deva.env.shells.interface import Shell
+
+if TYPE_CHECKING:
+    from deva.utils.fs import Path
+
+
+class BashShell(Shell):
+    def get_login_command(self, *, cwd: str) -> str:
+        return f"cd {self.join_args_unescaped([cwd])} && bash -l -i"
+
+    def format_command(self, args: list[str], *, cwd: str) -> str:
+        return f"cd {self.join_args_unescaped([cwd])} && {self.join_args_unescaped(args)}"
+
+    def collect_shared_files(self) -> list[Path]:
+        shared_files = super().collect_shared_files()
+
+        bash_history_file = self.shared_dir / "bash" / ".bash_history"
+        shared_files.append(bash_history_file)
+
+        bash_history_file.parent.ensure_dir()
+        bash_history_file.touch()
+
+        return shared_files

--- a/src/deva/env/shells/interface.py
+++ b/src/deva/env/shells/interface.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from deva.utils.fs import Path
+
+
+class Shell(ABC):
+    def __init__(self, shared_dir: Path) -> None:
+        self.__shared_dir = shared_dir / "shell"
+
+    @abstractmethod
+    def get_login_command(self, *, cwd: str) -> str:
+        """
+        Return the shell-specific command to start a login shell.
+        """
+
+    @abstractmethod
+    def format_command(self, args: list[str], *, cwd: str) -> str:
+        """
+        Format the shell-specific command for running a command with arguments.
+        """
+
+    def collect_shared_files(self) -> list[Path]:
+        """
+        Set up and return the shared shell-specific files.
+        """
+        shared_files: list[Path] = []
+
+        starship_config_file = Path.home() / ".config" / "starship.toml"
+        if starship_config_file.exists():
+            import shutil
+
+            shared_starship_config_file = self.shared_dir / "starship.toml"
+            shared_files.append(shared_starship_config_file)
+
+            self.shared_dir.ensure_dir()
+            shutil.copy(starship_config_file, shared_starship_config_file)
+
+        return shared_files
+
+    @property
+    def shared_dir(self) -> Path:
+        return self.__shared_dir
+
+    @staticmethod
+    def join_args_unescaped(args: list[str]) -> str:
+        return " ".join(f'"{arg}"' if " " in arg else arg for arg in args)

--- a/src/deva/env/shells/nu.py
+++ b/src/deva/env/shells/nu.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deva.env.shells.interface import Shell
+
+if TYPE_CHECKING:
+    from deva.utils.fs import Path
+
+
+class NuShell(Shell):
+    def get_login_command(self, *, cwd: str) -> str:
+        return self.__sh_command(["nu", "-l", "-i"], cwd=cwd)
+
+    def format_command(self, args: list[str], *, cwd: str) -> str:
+        import shlex
+
+        return self.__sh_command(["nu", "-c", shlex.join(args)], cwd=cwd)
+
+    def collect_shared_files(self) -> list[Path]:
+        shared_files = super().collect_shared_files()
+
+        nu_history_dir = self.shared_dir / "nu"
+        nu_history_dir.ensure_dir()
+
+        # https://sqlite.org/wal.html#walfile
+        # https://sqlite.org/walformat.html#shm
+        for history_file in ("history.sqlite3", "history.sqlite3-wal", "history.sqlite3-shm"):
+            nu_history_file = nu_history_dir / history_file
+            nu_history_file.touch()
+            shared_files.append(nu_history_file)
+
+        return shared_files
+
+    def __sh_command(self, args: list[str], *, cwd: str) -> str:
+        from deva.utils.platform import join_command_args
+
+        # https://github.com/nushell/nushell/issues/10219
+        return join_command_args([
+            "sh",
+            "-l",
+            "-c",
+            f"cd {self.join_args_unescaped([cwd])} && {join_command_args(args)}",
+        ])

--- a/src/deva/env/shells/zsh.py
+++ b/src/deva/env/shells/zsh.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deva.env.shells.interface import Shell
+
+if TYPE_CHECKING:
+    from deva.utils.fs import Path
+
+
+class ZshShell(Shell):
+    def get_login_command(self, *, cwd: str) -> str:
+        return f"cd {self.join_args_unescaped([cwd])} && zsh -l -i"
+
+    def format_command(self, args: list[str], *, cwd: str) -> str:
+        return f"cd {self.join_args_unescaped([cwd])} && {self.join_args_unescaped(args)}"
+
+    def collect_shared_files(self) -> list[Path]:
+        shared_files = super().collect_shared_files()
+
+        zsh_history_file = self.shared_dir / "zsh" / ".zsh_history"
+        shared_files.append(zsh_history_file)
+
+        zsh_history_file.parent.ensure_dir()
+        zsh_history_file.touch()
+
+        return shared_files

--- a/src/deva/env/ssh.py
+++ b/src/deva/env/ssh.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+
+def ensure_ssh_config(hostname: str) -> None:
+    from deva.utils.ssh import write_server_config
+
+    return write_server_config(
+        hostname, {"StrictHostKeyChecking": "no", "ForwardAgent": "yes", "UserKnownHostsFile": "/dev/null"}
+    )

--- a/src/deva/utils/retry.py
+++ b/src/deva/utils/retry.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def wait_for(condition: Callable[[], bool | None], timeout: float = 60, wait: float = 1) -> None:
+    start_time = time.monotonic()
+    while True:
+        try:
+            result = condition()
+        except Exception:
+            elapsed_time = time.monotonic() - start_time
+            if elapsed_time >= timeout:
+                raise
+
+            time.sleep(wait)
+            continue
+
+        if result is not False:
+            return
+
+        elapsed_time = time.monotonic() - start_time
+        if elapsed_time >= timeout:
+            raise TimeoutError
+
+        time.sleep(wait)

--- a/src/deva/utils/ssh.py
+++ b/src/deva/utils/ssh.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from deva.utils.fs import Path
+
+RELATIVE_CONFIG_DIR = ".deva"
+
+
+def ssh_config_dir() -> Path:
+    return Path.home() / ".ssh"
+
+
+def ssh_base_command(destination: str, ssh_port: int | str) -> list[str]:
+    return [
+        "ssh",
+        # Enable agent forwarding
+        "-A",
+        # Silence redundant output
+        "-q",
+        # Allocate pseudo-terminal, required for colored output and some commands
+        "-t",
+        "-p",
+        str(ssh_port),
+        destination,
+        # Indicate that there are no more flags
+        "--",
+    ]
+
+
+def derive_dynamic_ssh_port(key: str) -> int:
+    from hashlib import sha256
+
+    # https://en.wikipedia.org/wiki/Ephemeral_port
+    # https://datatracker.ietf.org/doc/html/rfc6335#section-6
+    # https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml
+    min_port = 49152
+    max_port = 65535
+
+    repo_id = int.from_bytes(sha256(key.encode("utf-8")).digest(), "big")
+    return repo_id % (max_port - min_port) + min_port
+
+
+def write_server_config(hostname: str, options: dict[str, str]) -> None:
+    config_file = ssh_config_dir() / RELATIVE_CONFIG_DIR / hostname
+    lines = [f"Host {hostname}"]
+    for key, value in options.items():
+        lines.append(f"    {key} {value}")
+
+    lines.append("")
+    config_file.parent.ensure_dir()
+    config_file.write_text("\n".join(lines), encoding="utf-8")
+    ensure_config_inclusion()
+
+
+def ensure_config_inclusion() -> None:
+    config_file = ssh_config_dir() / "config"
+    expected_line = f"Include {RELATIVE_CONFIG_DIR}/*"
+    lines = config_file.read_text(encoding="utf-8").splitlines() if config_file.exists() else []
+    if expected_line in lines:
+        return
+
+    new_lines = [expected_line, *lines, ""]
+    config_file.parent.ensure_dir()
+    config_file.write_text("\n".join(new_lines), encoding="utf-8")

--- a/tests/cli/config/test_set.py
+++ b/tests/cli/config/test_set.py
@@ -50,16 +50,17 @@ def test_value_integer_negative(deva, config_file, helpers):
 @pytest.mark.parametrize("value", [True, False])
 def test_value_boolean(deva, config_file, helpers, value):
     toml_value = str(value).lower()
-    result = deva("config", "set", "foo", toml_value)
+    result = deva("config", "set", "env.dev.universal-shell", toml_value)
 
     assert result.exit_code == 0, result.output
     assert result.output == helpers.dedent(
         f"""
-        foo = {toml_value}
+        [env.dev]
+        universal-shell = {toml_value}
         """
     )
 
-    assert config_file.data["foo"] is value
+    assert config_file.model.env.dev.universal_shell is value
 
 
 def test_value_deep(deva, config_file, helpers):

--- a/tests/cli/config/test_show.py
+++ b/tests/cli/config/test_show.py
@@ -22,10 +22,15 @@ def test_default_scrubbed(deva, config_file, helpers, default_cache_dir, default
 
         [env.dev]
         default-type = "{DEFAULT_DEV_ENV}"
+        universal-shell = false
 
         [storage]
         data = "{default_data_directory}"
         cache = "{default_cache_directory}"
+
+        [git.user]
+        name = "Foo Bar"
+        email = "foo@bar.baz"
 
         [github.auth]
         user = "foo"
@@ -62,10 +67,15 @@ def test_reveal(deva, config_file, helpers, default_cache_dir, default_data_dir)
 
         [env.dev]
         default-type = "{DEFAULT_DEV_ENV}"
+        universal-shell = false
 
         [storage]
         data = "{default_data_directory}"
         cache = "{default_cache_directory}"
+
+        [git.user]
+        name = "Foo Bar"
+        email = "foo@bar.baz"
 
         [github.auth]
         user = "foo"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,8 @@ def isolation() -> Generator[Path, None, None]:
             ConfigEnvVars.CACHE: str(cache_dir),
             AppEnvVars.NO_COLOR: "1",
             "DEVA_SELF_TESTING": "true",
+            "GIT_AUTHOR_NAME": "Foo Bar",
+            "GIT_AUTHOR_EMAIL": "foo@bar.baz",
             "COLUMNS": "80",
             "LINES": "24",
         }
@@ -94,6 +96,18 @@ def config_file(tmp_path: pathlib.Path) -> ConfigFile:
     config = ConfigFile(path)
     config.restore()
     return config
+
+
+@pytest.fixture
+def private_storage(config_file: ConfigFile) -> Generator[None, None, None]:
+    cache_dir = config_file.path.parent / "cache"
+    cache_dir.mkdir()
+    data_dir = config_file.path.parent / "data"
+    data_dir.mkdir()
+    config_file.data["storage"] = {"cache": str(cache_dir), "data": str(data_dir)}
+    config_file.save()
+    with EnvVars({ConfigEnvVars.CACHE: str(cache_dir), ConfigEnvVars.DATA: str(data_dir)}):
+        yield
 
 
 @pytest.fixture

--- a/tests/env/__init__.py
+++ b/tests/env/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/env/dev/__init__.py
+++ b/tests/env/dev/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/env/dev/test_interface.py
+++ b/tests/env/dev/test_interface.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import NoReturn
+
+import msgspec
+import pytest
+
+from deva.env.dev.interface import DeveloperEnvironmentConfig, DeveloperEnvironmentInterface
+from deva.env.models import EnvironmentState, EnvironmentStatus
+
+pytestmark = [pytest.mark.usefixtures("private_storage")]
+
+
+class Container(DeveloperEnvironmentInterface):
+    def start(self) -> None: ...
+
+    def stop(self) -> None: ...
+
+    def remove(self) -> None: ...
+
+    def status(self) -> EnvironmentStatus:
+        return EnvironmentStatus(state=EnvironmentState.UNKNOWN)
+
+    def launch_shell(self, *, repo: str | None = None) -> NoReturn: ...
+
+    def code(self, *, repo: str | None = None) -> None: ...
+
+    def run_command(self, command: list[str], *, repo: str | None = None) -> None: ...
+
+
+def test_storage_dirs(app, tmp_path):
+    container = Container(app=app, name="test", instance="default")
+
+    assert container.storage_dirs.cache == tmp_path / "cache" / "env" / "dev" / "test" / "default"
+    assert container.storage_dirs.data == tmp_path / "data" / "env" / "dev" / "test" / "default"
+
+
+class TestConfig:
+    def test_default_config(self, app):
+        container = Container(app=app, name="test", instance="default")
+
+        assert msgspec.to_builtins(container.config) == {
+            "repos": ["datadog-agent"],
+        }
+
+    def test_save(self, app):
+        config = DeveloperEnvironmentConfig(repos=["foo", "bar"])
+        container = Container(app=app, name="test", instance="default", config=config)
+        container.save_config()
+
+        container = Container(app=app, name="test", instance="default")
+        assert container.config.repos == ["foo", "bar"]
+
+    def test_remove(self, app):
+        config = DeveloperEnvironmentConfig(repos=["foo", "bar"])
+        container = Container(app=app, name="test", instance="default", config=config)
+        container.save_config()
+
+        container = Container(app=app, name="test", instance="default")
+        assert container.config.repos == ["foo", "bar"]
+
+        container = Container(app=app, name="test", instance="default")
+        container.remove_config()
+        assert container.config.repos == ["datadog-agent"]

--- a/tests/env/dev/types/__init__.py
+++ b/tests/env/dev/types/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -1,0 +1,591 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from subprocess import CompletedProcess
+
+import msgspec
+import pytest
+
+from deva.env.dev.types.linux_container import LinuxContainer
+from deva.utils.fs import Path
+
+pytestmark = [pytest.mark.usefixtures("private_storage")]
+
+
+@pytest.fixture(autouse=True)
+def updated_config(config_file):
+    # Allow Windows users to run these tests
+    if sys.platform == "win32":
+        config_file.data["env"] = {"dev": {"default-type": "linux-container"}}
+        config_file.save()
+
+
+def get_starship_mount(shared_dir: Path) -> list[str]:
+    starship_config_file = Path.home() / ".config" / "starship.toml"
+    if not starship_config_file.exists():
+        return []
+
+    return ["-v", f"{shared_dir / "shell" / "starship.toml"}:/root/.shared/shell/starship.toml"]
+
+
+def test_default_config(app):
+    container = LinuxContainer(app=app, name="linux-container", instance="default")
+
+    assert msgspec.to_builtins(container.config) == {
+        "cli": "docker",
+        "image": "datadog/agent-dev-env-linux",
+        "no_pull": False,
+        "repos": ["datadog-agent"],
+        "shell": "zsh",
+    }
+
+
+class TestStatus:
+    def test_default(self, deva, helpers, mocker):
+        mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
+        result = deva("env", "dev", "status")
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            State: nonexistent
+            """
+        )
+
+    @pytest.mark.parametrize(
+        ("state", "data"),
+        [
+            pytest.param("started", {"Status": "running"}, id="running"),
+            pytest.param("stopped", {"Status": "created"}, id="created"),
+            pytest.param("stopped", {"Status": "paused"}, id="paused"),
+            pytest.param("stopped", {"Status": "exited", "ExitCode": 0}, id="exited without error"),
+            pytest.param("error", {"Status": "exited", "ExitCode": 1}, id="exited with error"),
+            pytest.param("starting", {"Status": "restarting"}, id="restarting"),
+            pytest.param("stopping", {"Status": "removing"}, id="removing"),
+            pytest.param("unknown", {"Status": "foo"}, id="unknown"),
+        ],
+    )
+    def test_states(self, deva, helpers, mocker, state, data):
+        mocker.patch(
+            "subprocess.run",
+            return_value=CompletedProcess([], returncode=0, stdout=json.dumps([{"State": data}])),
+        )
+        result = deva("env", "dev", "status")
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            f"""
+            State: {state}
+            """
+        )
+
+
+class TestStart:
+    def test_already_started(self, deva, helpers):
+        with helpers.hybrid_patch(
+            "subprocess.run",
+            return_values={
+                # Start command checks the status
+                1: CompletedProcess([], returncode=0, stdout=json.dumps([{"State": {"Status": "running"}}])),
+            },
+        ):
+            result = deva("env", "dev", "start")
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            Cannot start developer environment `linux-container` in state `started`, must be one of: nonexistent, stopped
+            """
+        )
+
+    def test_default(self, deva, helpers, mocker, tmp_path):
+        write_server_config = mocker.patch("deva.utils.ssh.write_server_config")
+        with helpers.hybrid_patch(
+            "subprocess.run",
+            return_values={
+                # Start command checks the status
+                1: CompletedProcess([], returncode=0, stdout="{}"),
+                # Start method checks the status
+                2: CompletedProcess([], returncode=0, stdout="{}"),
+                # Capture image pull
+                # Capture container run
+                # Readiness check
+                5: CompletedProcess([], returncode=0, stdout="Server listening on :: port 22"),
+                # Capture repo cloning
+            },
+        ) as calls:
+            result = deva("env", "dev", "start")
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            Pulling image: datadog/agent-dev-env-linux
+            Creating and starting container: deva-linux-container-default
+            Waiting for container: deva-linux-container-default
+            Cloning repository: datadog-agent
+            """
+        )
+
+        write_server_config.assert_called_once_with(
+            "localhost",
+            {
+                "StrictHostKeyChecking": "no",
+                "ForwardAgent": "yes",
+                "UserKnownHostsFile": "/dev/null",
+            },
+        )
+
+        shared_dir = tmp_path / "data" / "env" / "dev" / "linux-container" / ".shared"
+        starship_mount = get_starship_mount(shared_dir)
+        assert calls == [
+            (
+                ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+            (
+                (
+                    [
+                        helpers.locate("docker"),
+                        "run",
+                        "--pull",
+                        "never",
+                        "-d",
+                        "--name",
+                        "deva-linux-container-default",
+                        "-p",
+                        "55909:22",
+                        "-e",
+                        "DD_SHELL=zsh",
+                        *starship_mount,
+                        "-v",
+                        f"{shared_dir / "shell" / "zsh" / ".zsh_history"}:/root/.shared/shell/zsh/.zsh_history",
+                        "datadog/agent-dev-env-linux",
+                    ],
+                ),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+            (
+                (
+                    [
+                        helpers.locate("ssh"),
+                        "-A",
+                        "-q",
+                        "-t",
+                        "-p",
+                        "55909",
+                        "root@localhost",
+                        "--",
+                        "cd /root && git dd-clone datadog-agent",
+                    ],
+                ),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+        ]
+
+    def test_no_pull(self, deva, helpers, mocker, tmp_path):
+        write_server_config = mocker.patch("deva.utils.ssh.write_server_config")
+        with helpers.hybrid_patch(
+            "subprocess.run",
+            return_values={
+                # Start command checks the status
+                1: CompletedProcess([], returncode=0, stdout="{}"),
+                # Start method checks the status
+                2: CompletedProcess([], returncode=0, stdout="{}"),
+                # Capture container run
+                # Readiness check
+                4: CompletedProcess([], returncode=0, stdout="Server listening on :: port 22"),
+                # Capture repo cloning
+            },
+        ) as calls:
+            result = deva("env", "dev", "start", "--no-pull")
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            Creating and starting container: deva-linux-container-default
+            Waiting for container: deva-linux-container-default
+            Cloning repository: datadog-agent
+            """
+        )
+
+        write_server_config.assert_called_once_with(
+            "localhost",
+            {
+                "StrictHostKeyChecking": "no",
+                "ForwardAgent": "yes",
+                "UserKnownHostsFile": "/dev/null",
+            },
+        )
+
+        shared_dir = tmp_path / "data" / "env" / "dev" / "linux-container" / ".shared"
+        starship_mount = get_starship_mount(shared_dir)
+        assert calls == [
+            (
+                (
+                    [
+                        helpers.locate("docker"),
+                        "run",
+                        "--pull",
+                        "never",
+                        "-d",
+                        "--name",
+                        "deva-linux-container-default",
+                        "-p",
+                        "55909:22",
+                        "-e",
+                        "DD_SHELL=zsh",
+                        *starship_mount,
+                        "-v",
+                        f"{shared_dir / "shell" / "zsh" / ".zsh_history"}:/root/.shared/shell/zsh/.zsh_history",
+                        "datadog/agent-dev-env-linux",
+                    ],
+                ),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+            (
+                (
+                    [
+                        helpers.locate("ssh"),
+                        "-A",
+                        "-q",
+                        "-t",
+                        "-p",
+                        "55909",
+                        "root@localhost",
+                        "--",
+                        "cd /root && git dd-clone datadog-agent",
+                    ],
+                ),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+        ]
+
+    def test_multiple_clones(self, deva, helpers, mocker, tmp_path):
+        write_server_config = mocker.patch("deva.utils.ssh.write_server_config")
+        with helpers.hybrid_patch(
+            "subprocess.run",
+            return_values={
+                # Start command checks the status
+                1: CompletedProcess([], returncode=0, stdout="{}"),
+                # Start method checks the status
+                2: CompletedProcess([], returncode=0, stdout="{}"),
+                # Capture image pull
+                # Capture container run
+                # Readiness check
+                5: CompletedProcess([], returncode=0, stdout="Server listening on :: port 22"),
+                # Capture repo cloning
+            },
+        ) as calls:
+            result = deva("env", "dev", "start", "-r", "datadog-agent@tag", "-r", "integrations-core")
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            Pulling image: datadog/agent-dev-env-linux
+            Creating and starting container: deva-linux-container-default
+            Waiting for container: deva-linux-container-default
+            Cloning repository: datadog-agent@tag
+            Cloning repository: integrations-core
+            """
+        )
+
+        write_server_config.assert_called_once_with(
+            "localhost",
+            {
+                "StrictHostKeyChecking": "no",
+                "ForwardAgent": "yes",
+                "UserKnownHostsFile": "/dev/null",
+            },
+        )
+
+        shared_dir = tmp_path / "data" / "env" / "dev" / "linux-container" / ".shared"
+        starship_mount = get_starship_mount(shared_dir)
+        assert calls == [
+            (
+                ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+            (
+                (
+                    [
+                        helpers.locate("docker"),
+                        "run",
+                        "--pull",
+                        "never",
+                        "-d",
+                        "--name",
+                        "deva-linux-container-default",
+                        "-p",
+                        "55909:22",
+                        "-e",
+                        "DD_SHELL=zsh",
+                        *starship_mount,
+                        "-v",
+                        f"{shared_dir / "shell" / "zsh" / ".zsh_history"}:/root/.shared/shell/zsh/.zsh_history",
+                        "datadog/agent-dev-env-linux",
+                    ],
+                ),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+            (
+                (
+                    [
+                        helpers.locate("ssh"),
+                        "-A",
+                        "-q",
+                        "-t",
+                        "-p",
+                        "55909",
+                        "root@localhost",
+                        "--",
+                        "cd /root && git dd-clone datadog-agent tag",
+                    ],
+                ),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+            (
+                (
+                    [
+                        helpers.locate("ssh"),
+                        "-A",
+                        "-q",
+                        "-t",
+                        "-p",
+                        "55909",
+                        "root@localhost",
+                        "--",
+                        "cd /root && git dd-clone integrations-core",
+                    ],
+                ),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+        ]
+
+
+class TestStop:
+    def test_nonexistent(self, deva, helpers, mocker):
+        mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
+
+        result = deva("env", "dev", "stop")
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            Cannot stop developer environment `linux-container` in state `nonexistent`, must be `started`
+            """
+        )
+
+    def test_default(self, deva, helpers):
+        with helpers.hybrid_patch(
+            "subprocess.run",
+            return_values={
+                # Stop command checks the status
+                1: CompletedProcess([], returncode=0, stdout=json.dumps([{"State": {"Status": "running"}}])),
+                # Capture container stop
+            },
+        ) as calls:
+            result = deva("env", "dev", "stop")
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            Stopping container: deva-linux-container-default
+            """
+        )
+
+        assert calls == [
+            (
+                ([helpers.locate("docker"), "stop", "-t", "0", "deva-linux-container-default"],),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+        ]
+
+
+class TestRemove:
+    def test_nonexistent(self, deva, helpers, mocker):
+        mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
+
+        result = deva("env", "dev", "remove")
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            Cannot remove developer environment `linux-container` in state `nonexistent`, must be one of: error, stopped
+            """
+        )
+
+    def test_default(self, deva, helpers):
+        with helpers.hybrid_patch(
+            "subprocess.run",
+            return_values={
+                # Stop command checks the status
+                1: CompletedProcess(
+                    [], returncode=0, stdout=json.dumps([{"State": {"Status": "exited", "ExitCode": 0}}])
+                ),
+                # Capture container removal
+            },
+        ) as calls:
+            result = deva("env", "dev", "remove")
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            Removing container: deva-linux-container-default
+            """
+        )
+
+        assert calls == [
+            (
+                ([helpers.locate("docker"), "rm", "-f", "deva-linux-container-default"],),
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+            ),
+        ]
+
+
+class TestShell:
+    def test_default(self, deva, mocker):
+        mocker.patch(
+            "subprocess.run",
+            return_value=CompletedProcess([], returncode=0, stdout=json.dumps([{"State": {"Status": "running"}}])),
+        )
+        write_server_config = mocker.patch("deva.utils.ssh.write_server_config")
+        exit_with_command = mocker.patch("deva.utils.process.SubprocessRunner.replace_current_process")
+
+        result = deva("env", "dev", "shell")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        write_server_config.assert_called_once_with(
+            "localhost",
+            {
+                "StrictHostKeyChecking": "no",
+                "ForwardAgent": "yes",
+                "UserKnownHostsFile": "/dev/null",
+            },
+        )
+        exit_with_command.assert_called_once_with([
+            "ssh",
+            "-A",
+            "-q",
+            "-t",
+            "-p",
+            "55909",
+            "root@localhost",
+            "--",
+            "cd /root/repos/datadog-agent && zsh -l -i",
+        ])
+
+
+class TestRun:
+    def test_nonexistent(self, deva, helpers, mocker):
+        mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
+
+        result = deva("env", "dev", "run", "echo", "foo")
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            Developer environment `linux-container` is in state `nonexistent`, must be `started`
+            """
+        )
+
+    def test_default(self, deva, helpers, mocker):
+        write_server_config = mocker.patch("deva.utils.ssh.write_server_config")
+
+        with helpers.hybrid_patch(
+            "subprocess.run",
+            return_values={
+                # Stop command checks the status
+                1: CompletedProcess([], returncode=0, stdout=json.dumps([{"State": {"Status": "running"}}])),
+                # Capture command run
+            },
+        ) as calls:
+            result = deva("env", "dev", "run", "echo", "foo")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        write_server_config.assert_called_once_with(
+            "localhost",
+            {
+                "StrictHostKeyChecking": "no",
+                "ForwardAgent": "yes",
+                "UserKnownHostsFile": "/dev/null",
+            },
+        )
+        assert calls == [
+            (
+                (
+                    [
+                        helpers.locate("ssh"),
+                        "-A",
+                        "-q",
+                        "-t",
+                        "-p",
+                        "55909",
+                        "root@localhost",
+                        "--",
+                        "cd /root/repos/datadog-agent && echo foo",
+                    ],
+                ),
+                {},
+            ),
+        ]
+
+
+class TestCode:
+    def test_nonexistent(self, deva, helpers, mocker):
+        mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
+
+        result = deva("env", "dev", "code")
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            Developer environment `linux-container` is in state `nonexistent`, must be `started`
+            """
+        )
+
+    def test_default(self, deva, helpers, mocker):
+        write_server_config = mocker.patch("deva.utils.ssh.write_server_config")
+
+        with helpers.hybrid_patch(
+            "subprocess.run",
+            return_values={
+                # Stop command checks the status
+                1: CompletedProcess([], returncode=0, stdout=json.dumps([{"State": {"Status": "running"}}])),
+                # Capture VS Code run
+            },
+        ) as calls:
+            result = deva("env", "dev", "code")
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        write_server_config.assert_called_once_with(
+            "localhost",
+            {
+                "StrictHostKeyChecking": "no",
+                "ForwardAgent": "yes",
+                "UserKnownHostsFile": "/dev/null",
+            },
+        )
+        assert calls == [
+            (
+                (
+                    [
+                        helpers.locate("code"),
+                        "--remote",
+                        "ssh-remote+root@localhost:55909",
+                        "/root/repos/datadog-agent",
+                    ],
+                ),
+                {},
+            ),
+        ]

--- a/tests/utils/test_retry.py
+++ b/tests/utils/test_retry.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import pytest
+
+from deva.utils.retry import wait_for
+
+
+class TestWaitFor:
+    def test_success(self):
+        wait_for(lambda: True, timeout=0)
+
+    def test_unmet(self):
+        with pytest.raises(TimeoutError):
+            wait_for(lambda: False, timeout=0)
+
+    def test_recover_from_unmet(self):
+        counter = 0
+
+        def condition():
+            nonlocal counter
+            if counter == 0:
+                counter += 1
+                return False
+
+            return True
+
+        wait_for(condition, wait=0)
+
+    def test_exception(self):
+        with pytest.raises(ZeroDivisionError):
+            wait_for(lambda: 9 / 0, timeout=0)
+
+    def test_recover_from_exception(self):
+        counter = 0
+
+        def condition():
+            nonlocal counter
+            if counter == 0:
+                counter += 1
+                raise ValueError
+
+            return True
+
+        wait_for(condition, wait=0)

--- a/tests/utils/test_ssh.py
+++ b/tests/utils/test_ssh.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import pytest
+
+from deva.utils.ssh import derive_dynamic_ssh_port, ssh_base_command
+
+
+@pytest.mark.parametrize("port", [pytest.param(22, id="int port"), pytest.param("22", id="str port")])
+def test_ssh_base_command(port: int | str) -> None:
+    assert ssh_base_command("host", port) == ["ssh", "-A", "-q", "-t", "-p", str(port), "host", "--"]
+
+
+def test_derive_dynamic_ssh_port() -> None:
+    assert 49152 <= derive_dynamic_ssh_port("key") <= 65535
+
+
+# https://github.com/pytest-dev/pyfakefs/issues/1086
+# @pytest.mark.usefixtures("fs")
+# def test_write_server_config() -> None:
+#     hostname = "localhost"
+#     write_server_config(hostname, {"foo": "bar", "baz": "qux"})
+
+#     config_file = Path.home() / ".ssh" / ".deva" / hostname
+#     assert config_file.is_file()


### PR DESCRIPTION
### Reviewer notes

- The implementation is fairly straightforward, I would recommend just running the commands. At a minimum `start`, `stop` and `ls`.
- There is not yet 100% test coverage but we should get this merged today so people can participate in the Sprint tomorrow.
- The next PRs (from me at least) will add the remaining tests, and telemetry like we have for the invoke tasks.