### PR TITLE
Add `--clone` flag to the `env dev start` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Changed:***
+
+- Use local versions of repositories rather than remote clones for developer environments by default
+
 ***Added:***
 
 - Allow repositories to require specific versions in a `.deva-version` or `.deva/version` file
+- Add `--clone` flag to the `env dev start` command to clone repositories rather than using local checkouts
 
 ## 0.1.0 - 2024-12-09
 

--- a/src/deva/cli/env/dev/start/__init__.py
+++ b/src/deva/cli/env/dev/start/__init__.py
@@ -50,6 +50,8 @@ def cmd(ctx: click.Context, *, env_type: str, instance: str) -> None:
     }
     user_config = dict(app.config.envs.get(env_type, {}))
     user_config.update(dynamic_options)
+    if "clone" not in user_config and app.config.env.dev.clone_repos:
+        user_config["clone"] = True
     if "shell" not in user_config and app.config.env.dev.universal_shell:
         user_config["shell"] = "nu"
 

--- a/src/deva/config/model/env.py
+++ b/src/deva/config/model/env.py
@@ -10,6 +10,7 @@ from deva.env.dev import DEFAULT_DEV_ENV
 
 class DevEnvConfig(Struct, frozen=True):
     default_type: str = field(name="default-type", default=DEFAULT_DEV_ENV)
+    clone_repos: bool = field(name="clone-repos", default=False)
     universal_shell: bool = field(name="universal-shell", default=False)
 
 

--- a/src/deva/env/dev/interface.py
+++ b/src/deva/env/dev/interface.py
@@ -29,6 +29,14 @@ supplied multiple times. Examples:
             }
         ),
     ] = msgspec.field(default_factory=lambda: ["datadog-agent"])
+    clone: Annotated[
+        bool,
+        msgspec.Meta(
+            extra={
+                "help": "Clone the repositories remotely rather than using local checkouts",
+            }
+        ),
+    ] = False
 
 
 if TYPE_CHECKING:

--- a/tests/cli/config/test_show.py
+++ b/tests/cli/config/test_show.py
@@ -22,6 +22,7 @@ def test_default_scrubbed(deva, config_file, helpers, default_cache_dir, default
 
         [env.dev]
         default-type = "{DEFAULT_DEV_ENV}"
+        clone-repos = false
         universal-shell = false
 
         [storage]
@@ -67,6 +68,7 @@ def test_reveal(deva, config_file, helpers, default_cache_dir, default_data_dir)
 
         [env.dev]
         default-type = "{DEFAULT_DEV_ENV}"
+        clone-repos = false
         universal-shell = false
 
         [storage]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,9 +51,7 @@ def deva():
 
 @pytest.fixture
 def temp_dir(tmp_path: pathlib.Path) -> Path:
-    path = Path(tmp_path, "temp")
-    path.mkdir()
-    return path
+    return Path(tmp_path)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/env/dev/test_interface.py
+++ b/tests/env/dev/test_interface.py
@@ -43,6 +43,7 @@ class TestConfig:
         container = Container(app=app, name="test", instance="default")
 
         assert msgspec.to_builtins(container.config) == {
+            "clone": False,
             "repos": ["datadog-agent"],
         }
 


### PR DESCRIPTION
Changes the default behavior of developer environments to use local versions of repositories rather than remote clones