### PR TITLE
Add `inv` command for ease of migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ jobs:
     name: Build artifacts
     runs-on: ubuntu-latest
 
+    env:
+      DEVA_BUILD_METADATA_CHECK: "true"
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import Any
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, *_args: Any, **_kwargs: Any) -> None:
+        import json
+        import os
+
+        expected_metadata = {
+            "dependencies": self.metadata.core.dependencies,
+            "features": self.metadata.core.optional_dependencies,
+        }
+        expected_content = f"{json.dumps(expected_metadata, indent=4)}\n"
+        metadata_file = os.path.join(self.root, "src", "deva", "metadata.json")
+
+        if os.environ.get("DEVA_BUILD_METADATA_CHECK") in {"1", "true"}:
+            if not os.path.isfile(metadata_file):
+                message = f"Metadata file not found: {metadata_file}"
+                raise FileNotFoundError(message)
+
+            with open(metadata_file, encoding="utf-8") as f:
+                actual_content = f.read()
+
+            if actual_content != expected_content:
+                message = f"Metadata file content mismatch, a rebuild is required: {metadata_file}"
+                raise ValueError(message)
+
+        with open(metadata_file, "w", encoding="utf-8") as f:
+            f.write(expected_content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,136 @@ dependencies = [
   "tomlkit~=0.13",
   # https://peps.python.org/pep-0696/
   "typing-extensions>=4.6.0; python_version < '3.13'",
+  "uv~=0.5.11",
+]
+
+[project.optional-dependencies]
+### The following dependencies were defined in the build image repo
+# https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements/constraints.txt
+legacy-constraints = [
+    "azure-identity==1.14.1",
+    "azure-mgmt-resource==23.0.1",
+    "jira==3.5.2",
+    "setuptools==42.0.2",
+    "virtualenv==16.7.9",
+    "wheel==0.40.0",
+]
+# https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements.txt
+legacy-build = [
+    "awscli==1.29.45",
+    "boto3==1.28.45",
+    "codeowners==0.6.0",
+    "datadog-api-client==2.29.0",
+    "docker-squash==1.1.0",
+    "docker==6.1.3",
+    "dulwich==0.21.6",
+    "invoke==2.2.0",
+    "mypy==1.10.0",
+    # https://github.com/pypa/setuptools/issues/4501
+    "packaging==24.1",
+    "parameterized==0.9.0",
+    "pygithub==1.59.1",
+    "python-gitlab==4.4.0",
+    "reno==3.5.0",
+    "requests==2.31.0",
+    "ruff==0.3.5",
+    "semver==2.10.0",
+    "toml==0.10.2",
+    # mypy
+    "types-pyyaml==6.0.12.20240311",
+    "types-requests==2.30.0",
+    "types-tabulate==0.9.0.20240106",
+    "types-toml==0.10.8.20240310",
+    # urllib3 major version 2, released on May 4th 2023, breaks botocore used
+    # by awscli (removed DEFAULT_CIPHERS list from urllib3.util.ssl_)
+    "urllib3==1.26.15",
+    "vulture==2.6",
+]
+# https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements/agent-deploy.txt
+legacy-agent-deploy = [
+    "azure-identity==1.14.1",
+    "azure-mgmt-resource==23.0.1",
+    "pygithub==1.59.1",
+    "setuptools==42.0.2",
+    "virtualenv==16.7.9",
+]
+# https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements/btf-gen.txt
+legacy-btf-gen = [
+    "awscli==1.29.45",
+    "invoke==2.2.0",
+    "python-gitlab==4.4.0",
+    "requests==2.31.0",
+]
+# https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements/circleci.txt
+legacy-circleci = [
+    "wheel==0.40.0",
+]
+# https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements/e2e.txt
+legacy-e2e = [
+    "codeowners==0.6.0",
+    "docker-squash==1.1.0",
+    "docker==6.1.3",
+    "invoke==2.2.0",
+    "packaging==24.1",
+    "reno==3.5.0",
+    "requests==2.31.0",
+    "python-gitlab==4.4.0",
+    "toml==0.10.2",
+]
+### The following dependencies were defined in the Agent tasks directory:
+# https://github.com/DataDog/datadog-agent/blob/main/tasks/requirements.txt
+legacy-tasks = [
+    "debugpy==1.8.2",
+    "datadog-agent-dev[legacy-build,legacy-docs,legacy-release,legacy-github,legacy-notifications]",
+]
+# https://github.com/DataDog/datadog-agent/blob/main/tasks/requirements_docs.txt
+legacy-docs = [
+    "mkdocs~=1.5.3",
+    "mkdocs-material~=9.5.1",
+    # Plugins
+    "mkdocs-minify-plugin~=0.7.1",
+    "mkdocs-git-revision-date-localized-plugin~=1.2.1",
+    "mkdocs-glightbox~=0.3.5",
+    # Extensions
+    "pymdown-extensions~=10.5.0",
+    # Necessary for syntax highlighting in code blocks
+    "pygments~=2.17.2",
+    # Validation
+    "linkchecker~=10.5.0",
+]
+# https://github.com/DataDog/datadog-agent/blob/main/tasks/requirements_release_tasks.txt
+legacy-release = [
+    "atlassian-python-api==3.41.3",
+    "pandoc==2.4",
+    "reno==3.5.0",
+    "yattag==1.15.2",
+]
+# https://github.com/DataDog/datadog-agent/blob/main/tasks/libs/requirements-github.txt
+legacy-github = [
+    "beautifulsoup4~=4.12.3",
+    "cryptography==39.0.1",
+    "lxml~=5.2.2",
+    "pygithub==1.59.1",
+    "pyjwt==2.4.0",
+    "toml~=0.10.2",
+    "slack-sdk~=3.27.1",
+]
+# https://github.com/DataDog/datadog-agent/blob/main/tasks/libs/requirements-notifications.txt
+legacy-notifications = [
+    "codeowners==0.6.0",
+    "invoke==2.2.0",
+    "requests==2.31.0",
+    "pyyaml==6.0.1",
+    "slack-sdk~=3.27.1",
+]
+# https://github.com/DataDog/datadog-agent/blob/main/tasks/kernel_matrix_testing/requirements.txt
+legacy-kernel-matrix-testing = [
+    "jinja2==3.0.3",
+    "libvirt-python==10.9.0",
+    "termcolor==2.5.0",
+    "thefuzz==0.22.1",
+    "python-levenshtein==0.26.1",
+    "tabulate[widechars]==0.9.0",
 ]
 
 [project.urls]
@@ -47,6 +177,7 @@ deva = "deva.cli:main"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.build.hooks.custom]
 [tool.hatch.build.targets.wheel]
 packages = ["src/deva"]
 

--- a/src/deva/cli/__init__.py
+++ b/src/deva/cli/__init__.py
@@ -19,6 +19,7 @@ from deva.config.constants import AppEnvVars, ConfigEnvVars
     subcommands=(
         "config",
         "env",
+        "inv",
     ),
 )
 @click.rich_config(

--- a/src/deva/cli/application.py
+++ b/src/deva/cli/application.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
     from deva.config.file import ConfigFile
     from deva.config.model import RootConfig
+    from deva.tools import Tools
     from deva.utils.process import SubprocessRunner
 
 
@@ -38,7 +39,21 @@ class Application(Terminal):
         return self.__config_file.model
 
     @cached_property
+    def metadata(self) -> dict[str, Any]:
+        import json
+        from importlib import resources
+
+        content = resources.files("deva").joinpath("metadata.json").read_text(encoding="utf-8")
+        return json.loads(content)
+
+    @cached_property
     def subprocess(self) -> SubprocessRunner:
         from deva.utils.process import SubprocessRunner
 
         return SubprocessRunner(self)
+
+    @cached_property
+    def tools(self) -> Tools:
+        from deva.tools import Tools
+
+        return Tools(self)

--- a/src/deva/cli/inv/__init__.py
+++ b/src/deva/cli/inv/__init__.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from deva.cli.base import dynamic_command, ensure_deps_installed
+from deva.config.constants import AppEnvVars
+
+if TYPE_CHECKING:
+    from deva.cli.application import Application
+
+
+@dynamic_command(
+    short_help="Invoke a local task",
+    context_settings={"help_option_names": [], "ignore_unknown_options": True},
+)
+@click.argument("args", nargs=-1)
+@click.option(
+    "--no-dynamic-deps",
+    envvar=AppEnvVars.NO_DYNAMIC_DEPS,
+    is_flag=True,
+    help="Assume required dependencies are already installed",
+)
+@click.pass_obj
+def cmd(app: Application, *, args: tuple[str, ...], no_dynamic_deps: bool) -> None:
+    """
+    Invoke a local task.
+    """
+    features = app.metadata["features"]
+    required_deps = list(features["legacy-tasks"])
+
+    invoke_args = [arg for arg in args if not arg.startswith("-")]
+    if invoke_args:
+        task = invoke_args[0]
+        if task.startswith("system-probe."):
+            required_deps.extend(features["legacy-btf-gen"])
+        elif task.startswith("kmt."):
+            required_deps.extend(features["legacy-kernel-matrix-testing"])
+
+    if no_dynamic_deps:
+        app.subprocess.replace_current_process(["python", "-m", "invoke", *args])
+        return
+
+    venv_path = app.config.storage.join("venvs", "legacy").data
+    with app.tools.uv.virtual_env(venv_path) as venv:
+        ensure_deps_installed(
+            app,
+            required_deps,
+            constraints=features["legacy-constraints"],
+            sys_path=venv.get_sys_path(app),
+        )
+        app.subprocess.replace_current_process(["python", "-m", "invoke", *args])

--- a/src/deva/config/constants.py
+++ b/src/deva/config/constants.py
@@ -10,6 +10,7 @@ class AppEnvVars:
     INTERACTIVE = "DEVA_INTERACTIVE"
     QUIET = "DEVA_QUIET"
     VERBOSE = "DEVA_VERBOSE"
+    NO_DYNAMIC_DEPS = "DEVA_NO_DYNAMIC_DEPS"
     # https://no-color.org
     NO_COLOR = "NO_COLOR"
     FORCE_COLOR = "FORCE_COLOR"

--- a/src/deva/metadata.json
+++ b/src/deva/metadata.json
@@ -1,0 +1,163 @@
+{
+    "dependencies": [
+        "click~=8.1",
+        "dep-sync~=0.1",
+        "find-exe~=0.1",
+        "msgspec-click~=0.2",
+        "msgspec~=0.18",
+        "platformdirs~=4.2",
+        "rich-click~=1.8",
+        "rich~=13.7",
+        "tomlkit~=0.13",
+        "typing-extensions>=4.6.0; python_version < '3.13'",
+        "uv~=0.5.11"
+    ],
+    "features": {
+        "legacy-agent-deploy": [
+            "azure-identity==1.14.1",
+            "azure-mgmt-resource==23.0.1",
+            "pygithub==1.59.1",
+            "setuptools==42.0.2",
+            "virtualenv==16.7.9"
+        ],
+        "legacy-btf-gen": [
+            "awscli==1.29.45",
+            "invoke==2.2.0",
+            "python-gitlab==4.4.0",
+            "requests==2.31.0"
+        ],
+        "legacy-build": [
+            "awscli==1.29.45",
+            "boto3==1.28.45",
+            "codeowners==0.6.0",
+            "datadog-api-client==2.29.0",
+            "docker-squash==1.1.0",
+            "docker==6.1.3",
+            "dulwich==0.21.6",
+            "invoke==2.2.0",
+            "mypy==1.10.0",
+            "packaging==24.1",
+            "parameterized==0.9.0",
+            "pygithub==1.59.1",
+            "python-gitlab==4.4.0",
+            "reno==3.5.0",
+            "requests==2.31.0",
+            "ruff==0.3.5",
+            "semver==2.10.0",
+            "toml==0.10.2",
+            "types-pyyaml==6.0.12.20240311",
+            "types-requests==2.30.0",
+            "types-tabulate==0.9.0.20240106",
+            "types-toml==0.10.8.20240310",
+            "urllib3==1.26.15",
+            "vulture==2.6"
+        ],
+        "legacy-circleci": [
+            "wheel==0.40.0"
+        ],
+        "legacy-constraints": [
+            "azure-identity==1.14.1",
+            "azure-mgmt-resource==23.0.1",
+            "jira==3.5.2",
+            "setuptools==42.0.2",
+            "virtualenv==16.7.9",
+            "wheel==0.40.0"
+        ],
+        "legacy-docs": [
+            "linkchecker~=10.5.0",
+            "mkdocs-git-revision-date-localized-plugin~=1.2.1",
+            "mkdocs-glightbox~=0.3.5",
+            "mkdocs-material~=9.5.1",
+            "mkdocs-minify-plugin~=0.7.1",
+            "mkdocs~=1.5.3",
+            "pygments~=2.17.2",
+            "pymdown-extensions~=10.5.0"
+        ],
+        "legacy-e2e": [
+            "codeowners==0.6.0",
+            "docker-squash==1.1.0",
+            "docker==6.1.3",
+            "invoke==2.2.0",
+            "packaging==24.1",
+            "python-gitlab==4.4.0",
+            "reno==3.5.0",
+            "requests==2.31.0",
+            "toml==0.10.2"
+        ],
+        "legacy-github": [
+            "beautifulsoup4~=4.12.3",
+            "cryptography==39.0.1",
+            "lxml~=5.2.2",
+            "pygithub==1.59.1",
+            "pyjwt==2.4.0",
+            "slack-sdk~=3.27.1",
+            "toml~=0.10.2"
+        ],
+        "legacy-kernel-matrix-testing": [
+            "jinja2==3.0.3",
+            "libvirt-python==10.9.0",
+            "python-levenshtein==0.26.1",
+            "tabulate[widechars]==0.9.0",
+            "termcolor==2.5.0",
+            "thefuzz==0.22.1"
+        ],
+        "legacy-notifications": [
+            "codeowners==0.6.0",
+            "invoke==2.2.0",
+            "pyyaml==6.0.1",
+            "requests==2.31.0",
+            "slack-sdk~=3.27.1"
+        ],
+        "legacy-release": [
+            "atlassian-python-api==3.41.3",
+            "pandoc==2.4",
+            "reno==3.5.0",
+            "yattag==1.15.2"
+        ],
+        "legacy-tasks": [
+            "atlassian-python-api==3.41.3",
+            "awscli==1.29.45",
+            "beautifulsoup4~=4.12.3",
+            "boto3==1.28.45",
+            "codeowners==0.6.0",
+            "cryptography==39.0.1",
+            "datadog-api-client==2.29.0",
+            "debugpy==1.8.2",
+            "docker-squash==1.1.0",
+            "docker==6.1.3",
+            "dulwich==0.21.6",
+            "invoke==2.2.0",
+            "linkchecker~=10.5.0",
+            "lxml~=5.2.2",
+            "mkdocs-git-revision-date-localized-plugin~=1.2.1",
+            "mkdocs-glightbox~=0.3.5",
+            "mkdocs-material~=9.5.1",
+            "mkdocs-minify-plugin~=0.7.1",
+            "mkdocs~=1.5.3",
+            "mypy==1.10.0",
+            "packaging==24.1",
+            "pandoc==2.4",
+            "parameterized==0.9.0",
+            "pygithub==1.59.1",
+            "pygments~=2.17.2",
+            "pyjwt==2.4.0",
+            "pymdown-extensions~=10.5.0",
+            "python-gitlab==4.4.0",
+            "pyyaml==6.0.1",
+            "reno==3.5.0",
+            "requests==2.31.0",
+            "ruff==0.3.5",
+            "semver==2.10.0",
+            "slack-sdk~=3.27.1",
+            "toml==0.10.2",
+            "toml~=0.10.2",
+            "types-pyyaml==6.0.12.20240311",
+            "types-requests==2.30.0",
+            "types-tabulate==0.9.0.20240106",
+            "types-toml==0.10.8.20240310",
+            "urllib3==1.26.15",
+            "vulture==2.6",
+            "yattag==1.15.2"
+        ]
+    }
+}

--- a/src/deva/tools/__init__.py
+++ b/src/deva/tools/__init__.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deva.cli.application import Application
+    from deva.tools.uv import UV
+
+
+class Tools:
+    def __init__(self, app: Application) -> None:
+        self.__app = app
+
+    @cached_property
+    def uv(self) -> UV:
+        from deva.tools.uv import UV
+
+        return UV(self.__app)

--- a/src/deva/tools/base.py
+++ b/src/deva/tools/base.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from functools import cached_property
+from typing import TYPE_CHECKING, Any, NoReturn
+
+if TYPE_CHECKING:
+    from subprocess import CompletedProcess
+
+    from deva.cli.application import Application
+
+
+class Tool(ABC):
+    def __init__(self, app: Application) -> None:
+        self.__app = app
+
+    @abstractmethod
+    def format_command(self, command: list[str]) -> list[str]:
+        """Return the formatted command."""
+
+    @cached_property
+    def app(self) -> Application:
+        return self.__app
+
+    def wait(self, command: list[str], *args: Any, **kwargs: Any) -> None:
+        self.app.subprocess.wait(self.format_command(command), *args, **kwargs)
+
+    def run(self, command: list[str], *args: Any, **kwargs: Any) -> CompletedProcess:
+        return self.app.subprocess.run(self.format_command(command), *args, **kwargs)
+
+    def capture(self, command: list[str], *args: Any, **kwargs: Any) -> str:
+        return self.app.subprocess.capture(self.format_command(command), *args, **kwargs)
+
+    def replace_current_process(self, command: list[str], *args: Any, **kwargs: Any) -> NoReturn:
+        self.app.subprocess.replace_current_process(self.format_command(command), *args, **kwargs)

--- a/src/deva/tools/uv.py
+++ b/src/deva/tools/uv.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import contextmanager
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from deva.tools.base import Tool
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from deva.utils.fs import Path
+    from deva.utils.venv import VirtualEnv
+
+
+class UV(Tool):
+    def format_command(self, command: list[str]) -> list[str]:
+        return [self.path, *command]
+
+    @cached_property
+    def path(self) -> str:
+        import shutil
+        import sysconfig
+
+        scripts_dir = sysconfig.get_path("scripts")
+        old_path = os.environ.get("PATH", os.defpath)
+        new_path = f"{scripts_dir}{os.pathsep}{old_path}"
+        return shutil.which("uv", path=new_path) or "uv"
+
+    @contextmanager
+    def virtual_env(self, path: Path) -> Generator[VirtualEnv, None, None]:
+        from deva.utils.venv import VirtualEnv
+
+        if not path.is_dir():
+            self.run(["venv", str(path), "--seed", "--python", sys.executable])
+
+        with VirtualEnv(path) as venv:
+            yield venv

--- a/src/deva/utils/venv.py
+++ b/src/deva/utils/venv.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import os
+from functools import cached_property
+from typing import TYPE_CHECKING, Self
+
+from deva.utils.platform import PLATFORM_ID
+from deva.utils.process import EnvVars
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from deva.cli.application import Application
+    from deva.utils.fs import Path
+
+
+class VirtualEnv:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    if PLATFORM_ID == "windows":
+
+        @cached_property
+        def exe_dir(self) -> Path:
+            return self.path / "Scripts"
+
+    else:
+
+        @cached_property
+        def exe_dir(self) -> Path:
+            return self.path / "bin"
+
+    @staticmethod
+    def get_sys_path(app: Application) -> list[str]:
+        from ast import literal_eval
+
+        output = app.subprocess.capture(["python", "-c", "import sys;print([path for path in sys.path if path])"])
+        return literal_eval(output)
+
+    @cached_property
+    def __env_vars(self) -> EnvVars:
+        old_path = os.environ.get("PATH", os.defpath)
+        new_path = f"{self.exe_dir}{os.pathsep}{old_path}"
+        return EnvVars(
+            {"PATH": new_path, "VIRTUAL_ENV": str(self.path)},
+            # The presence of these environment variables is known to cause issues
+            exclude=["PYTHONHOME", "__PYVENV_LAUNCHER__"],
+        )
+
+    def __enter__(self) -> Self:
+        self.__env_vars.__enter__()
+        return self
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None
+    ) -> None:
+        env_vars = self.__env_vars
+        # The next context manager should take a new snapshot of the current process' environment variables
+        del self.__env_vars
+        env_vars.__exit__(exc_type, exc_value, traceback)

--- a/tests/cli/inv/__init__.py
+++ b/tests/cli/inv/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/cli/inv/test_inv.py
+++ b/tests/cli/inv/test_inv.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2024-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import sys
+from subprocess import CompletedProcess
+from unittest import mock
+
+import pytest
+
+from deva.config.constants import AppEnvVars
+from deva.utils.process import EnvVars
+
+pytestmark = [pytest.mark.usefixtures("private_storage")]
+
+
+def test_default(deva, helpers, temp_dir, uv_on_path, mocker):
+    replace_current_process = mocker.patch("deva.utils.process.SubprocessRunner.replace_current_process")
+    with helpers.hybrid_patch(
+        "subprocess.run",
+        return_values={
+            # Create virtual environment
+            # Get `sys.path` from virtual environment's Python
+            2: CompletedProcess([], returncode=0, stdout=repr(sys.path)),
+            # Capture dependency installation
+        },
+    ) as subprocess_run_calls:
+        result = deva("inv", "foo")
+
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        """
+        Synchronizing dependencies...
+        """
+    )
+
+    assert subprocess_run_calls == [
+        (
+            (
+                [
+                    uv_on_path,
+                    "venv",
+                    str(temp_dir / "data" / "venvs" / "legacy"),
+                    "--seed",
+                    "--python",
+                    sys.executable,
+                ],
+            ),
+            {},
+        ),
+        (
+            (
+                [
+                    uv_on_path,
+                    "pip",
+                    "install",
+                    "-r",
+                    mock.ANY,
+                    "-c",
+                    mock.ANY,
+                ],
+            ),
+            {},
+        ),
+    ]
+    assert replace_current_process.call_args_list == [
+        mock.call(
+            [
+                "python",
+                "-m",
+                "invoke",
+                "foo",
+            ],
+        )
+    ]
+
+
+def test_no_dynamic_deps_flag(deva, mocker):
+    replace_current_process = mocker.patch("deva.utils.process.SubprocessRunner.replace_current_process")
+
+    result = deva("inv", "--no-dynamic-deps", "foo")
+
+    assert result.exit_code == 0, result.output
+    assert not result.output
+
+    assert replace_current_process.call_args_list == [
+        mock.call(
+            [
+                "python",
+                "-m",
+                "invoke",
+                "foo",
+            ],
+        )
+    ]
+
+
+def test_no_dynamic_deps_env_var(deva, mocker):
+    replace_current_process = mocker.patch("deva.utils.process.SubprocessRunner.replace_current_process")
+
+    with EnvVars({AppEnvVars.NO_DYNAMIC_DEPS: "1"}):
+        result = deva("inv", "foo")
+
+    assert result.exit_code == 0, result.output
+    assert not result.output
+
+    assert replace_current_process.call_args_list == [
+        mock.call(
+            [
+                "python",
+                "-m",
+                "invoke",
+                "foo",
+            ],
+        )
+    ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import shutil
 import sys
 from typing import TYPE_CHECKING
 
@@ -121,6 +122,11 @@ def default_data_dir() -> Path:
 @pytest.fixture(scope="session")
 def default_cache_dir() -> Path:
     return Path(user_cache_dir("deva", appauthor=False))
+
+
+@pytest.fixture(scope="session")
+def uv_on_path():
+    return shutil.which("uv")
 
 
 def pytest_runtest_setup(item):

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -603,7 +603,7 @@ class TestShell:
             return_value=CompletedProcess([], returncode=0, stdout=json.dumps([{"State": {"Status": "running"}}])),
         )
         write_server_config = mocker.patch("deva.utils.ssh.write_server_config")
-        exit_with_command = mocker.patch("deva.utils.process.SubprocessRunner.replace_current_process")
+        replace_current_process = mocker.patch("deva.utils.process.SubprocessRunner.replace_current_process")
 
         result = deva("env", "dev", "shell")
 
@@ -618,7 +618,7 @@ class TestShell:
                 "UserKnownHostsFile": "/dev/null",
             },
         )
-        exit_with_command.assert_called_once_with([
+        replace_current_process.assert_called_once_with([
             "ssh",
             "-A",
             "-q",


### PR DESCRIPTION
This adds an `inv` command that will forward arguments to Invoke. The command automatically manages required dependencies in a virtual environment unless the `DEVA_NO_DYNAMIC_DEPS` environment variable is enabled or the `--no-dynamic-deps` flag is used.

The dependencies are now defined here as project metadata and upon builds updates a JSON file that is shipped. If this file is not in sync with the metadata then the CI build job will fail.

Reviewers should confirm all dependency files are accounted for from the various repos and confirm which invoke tasks require extra dependencies (see `src/deva/cli/inv/__init__.py`).