### PR TITLE
Support the `test-infra-definitions` repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- The `inv` command now supports the dependencies of tasks defined in the `test-infra-definitions` repo
+
 ## 0.2.0 - 2025-01-02
 
 ***Changed:***

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,14 @@ legacy-kernel-matrix-testing = [
     "python-levenshtein==0.26.1",
     "tabulate[widechars]==0.9.0",
 ]
+# https://github.com/DataDog/test-infra-definitions/blob/main/requirements.txt
+legacy-test-infra-definitions = [
+    "colorama>=0.4.6",
+    "pydantic==2.10.4",
+    "pyperclip==1.9.0",
+    "pyright==1.1.391",
+    "termcolor==2.5.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/DataDog/datadog-agent-dev"

--- a/src/deva/cli/inv/__init__.py
+++ b/src/deva/cli/inv/__init__.py
@@ -30,13 +30,17 @@ def cmd(app: Application, *, args: tuple[str, ...], no_dynamic_deps: bool) -> No
     """
     Invoke a local task.
     """
+    from deva.utils.fs import Path
+
     features = app.metadata["features"]
     required_deps = list(features["legacy-tasks"])
 
     invoke_args = [arg for arg in args if not arg.startswith("-")]
     if invoke_args:
         task = invoke_args[0]
-        if task.startswith("system-probe."):
+        if Path.cwd().name == "test-infra-definitions":
+            required_deps.extend(features["legacy-test-infra-definitions"])
+        elif task.startswith("system-probe."):
             required_deps.extend(features["legacy-btf-gen"])
         elif task.startswith("kmt."):
             required_deps.extend(features["legacy-kernel-matrix-testing"])

--- a/src/deva/metadata.json
+++ b/src/deva/metadata.json
@@ -158,6 +158,13 @@
             "urllib3==1.26.15",
             "vulture==2.6",
             "yattag==1.15.2"
+        ],
+        "legacy-test-infra-definitions": [
+            "colorama>=0.4.6",
+            "pydantic==2.10.4",
+            "pyperclip==1.9.0",
+            "pyright==1.1.391",
+            "termcolor==2.5.0"
         ]
     }
 }


### PR DESCRIPTION
I removed the dependencies that were already defined by other default features, some of them had conflicts so couldn't actually work anyway except by accident