### PR TITLE
Repository version files now define a minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Repository-specific version files (`.deva-version` or `.deva/version`) now define the minimum required version rather than the exact version
+
 ## 0.4.1 - 2025-01-18
 
 ***Fixed:***

--- a/src/deva/cli/__init__.py
+++ b/src/deva/cli/__init__.py
@@ -153,8 +153,18 @@ def deva(
     cwd = Path.cwd()
     if (version_file := cwd / ".deva-version").is_file() or (version_file := cwd / ".deva" / "version").is_file():
         pinned_version = version_file.read_text().strip()
-        if pinned_version != __version__:
-            app.abort(f"deva version mismatch: {__version__} != {pinned_version}")
+        pinned_version_parts = list(map(int, pinned_version.split(".")))
+        # Limit to X.Y.Z in case of dev versions e.g. 1.2.3.dev1
+        current_version_parts = list(map(int, __version__.split(".")[:3]))
+
+        if current_version_parts < pinned_version_parts:
+            app.display_critical(
+                f"Repo requires at least deva version {pinned_version} but {__version__} is installed."
+            )
+            if app.managed_installation:
+                app.display("Run the following command:\ndeva self update")
+
+            app.abort()
 
     # Persist app data for sub-commands
     ctx.obj = app

--- a/src/deva/cli/application.py
+++ b/src/deva/cli/application.py
@@ -55,3 +55,7 @@ class Application(Terminal):
     @cached_property
     def dynamic_deps_allowed(self) -> bool:
         return os.getenv(AppEnvVars.NO_DYNAMIC_DEPS) not in {"1", "true"}
+
+    @cached_property
+    def managed_installation(self) -> bool:
+        return os.getenv("PYAPP") is not None

--- a/tests/cli/test_pin.py
+++ b/tests/cli/test_pin.py
@@ -3,35 +3,48 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
+import pytest
+
 from deva._version import __version__
 
 
+@pytest.fixture(scope="module")
+def next_major_version():
+    version_parts = list(map(int, __version__.split(".")[:3]))
+    version_parts[0] += 1
+    return ".".join(map(str, version_parts))
+
+
 class TestVersionMismatch:
-    def test_root(self, deva, helpers, temp_dir):
+    def test_root(self, deva, helpers, temp_dir, next_major_version):
         version_file = temp_dir / ".deva-version"
         with temp_dir.as_cwd():
-            version_file.write_text("0.0.0")
+            version_file.write_text(next_major_version)
 
             result = deva("config")
 
         assert result.exit_code == 1, result.output
         assert result.output == helpers.dedent(
             f"""
-            deva version mismatch: {__version__} != 0.0.0
+            Repo requires at least deva version {next_major_version} but {__version__} is installed.
+            Run the following command:
+            deva self update
             """
         )
 
-    def test_directory(self, deva, helpers, temp_dir):
+    def test_directory(self, deva, helpers, temp_dir, next_major_version):
         version_file = temp_dir / ".deva" / "version"
         version_file.parent.ensure_dir()
         with temp_dir.as_cwd():
-            version_file.write_text("0.0.0")
+            version_file.write_text(next_major_version)
 
             result = deva("config")
 
         assert result.exit_code == 1, result.output
         assert result.output == helpers.dedent(
             f"""
-            deva version mismatch: {__version__} != 0.0.0
+            Repo requires at least deva version {next_major_version} but {__version__} is installed.
+            Run the following command:
+            deva self update
             """
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,7 @@ def isolation() -> Generator[Path, None, None]:
             ConfigEnvVars.DATA: str(data_dir),
             ConfigEnvVars.CACHE: str(cache_dir),
             AppEnvVars.NO_COLOR: "1",
+            "PYAPP": "1",
             "DEVA_SELF_TESTING": "true",
             "GIT_AUTHOR_NAME": "Foo Bar",
             "GIT_AUTHOR_EMAIL": "foo@bar.baz",


### PR DESCRIPTION
Developers would encounter errors frequently because the default installation method is to get the latest available version, and in the case of CI/CD the exact version is already used for the download so it's redundant