### PR TITLE
Remove dynamic installation of KMT dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Remove dynamic installation of `legacy-kernel-matrix-testing` dependencies
+
 ## 0.5.0 - 2025-02-25
 
 ***Changed:***

--- a/src/dda/cli/inv/__init__.py
+++ b/src/dda/cli/inv/__init__.py
@@ -40,14 +40,11 @@ def cmd(app: Application, *, args: tuple[str, ...], no_dynamic_deps: bool) -> No
             features.append("legacy-test-infra-definitions")
         elif task.startswith("system-probe."):
             features.append("legacy-btf-gen")
-        elif task.startswith("kmt."):
-            features.append("legacy-kernel-matrix-testing")
 
     if no_dynamic_deps:
         import sys
 
         app.subprocess.replace_current_process([sys.executable, "-m", "invoke", *args])
-        return
 
     venv_path = app.config.storage.join("venvs", "legacy").data
     with app.tools.uv.virtual_env(venv_path) as venv:

--- a/tests/cli/inv/test_inv.py
+++ b/tests/cli/inv/test_inv.py
@@ -16,7 +16,10 @@ pytestmark = [pytest.mark.usefixtures("private_storage")]
 
 
 def test_default(dda, helpers, temp_dir, uv_on_path, mocker):
-    replace_current_process = mocker.patch("dda.utils.process.SubprocessRunner.replace_current_process")
+    replace_current_process = mocker.patch(
+        "dda.utils.process.SubprocessRunner.replace_current_process",
+        side_effect=lambda *args, **kwargs: sys.exit(0),  # noqa: ARG005
+    )
     subprocess_run = mocker.patch("subprocess.run", return_value=subprocess.CompletedProcess([], returncode=0))
 
     result = dda("inv", "foo")
@@ -73,7 +76,10 @@ def test_default(dda, helpers, temp_dir, uv_on_path, mocker):
 
 
 def test_no_dynamic_deps_flag(dda, mocker):
-    replace_current_process = mocker.patch("dda.utils.process.SubprocessRunner.replace_current_process")
+    replace_current_process = mocker.patch(
+        "dda.utils.process.SubprocessRunner.replace_current_process",
+        side_effect=lambda *args, **kwargs: sys.exit(0),  # noqa: ARG005
+    )
 
     result = dda("inv", "--no-dynamic-deps", "foo")
 
@@ -93,7 +99,10 @@ def test_no_dynamic_deps_flag(dda, mocker):
 
 
 def test_no_dynamic_deps_env_var(dda, mocker):
-    replace_current_process = mocker.patch("dda.utils.process.SubprocessRunner.replace_current_process")
+    replace_current_process = mocker.patch(
+        "dda.utils.process.SubprocessRunner.replace_current_process",
+        side_effect=lambda *args, **kwargs: sys.exit(0),  # noqa: ARG005
+    )
 
     with EnvVars({AppEnvVars.NO_DYNAMIC_DEPS: "1"}):
         result = dda("inv", "foo")


### PR DESCRIPTION
Dependencies must be manually installed only after system requirements are met, see https://github.com/DataDog/datadog-agent/pull/33587#discussion_r1981288764