### PR TITLE
fix(install): Force a split of arguments

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -38,4 +38,4 @@ jobs:
         DDA_INSTALL_FEATURES: legacy-tasks
 
     - name: Verify
-      run: deva --version
+      run: dda --version

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -34,8 +34,8 @@ jobs:
       run: "'${{ github.workspace }}${{ runner.os == 'Windows' && '\\' || '/' }}main.sh'"
       shell: bash
       env:
-        DEVA_INSTALL_VERSION: latest
-        DEVA_INSTALL_FEATURES: legacy-tasks
+        DDA_INSTALL_VERSION: latest
+        DDA_INSTALL_FEATURES: legacy-tasks
 
     - name: Verify
       run: deva --version

--- a/main.sh
+++ b/main.sh
@@ -28,7 +28,7 @@ install_features() {
     echo -e "${PURPLE}Installing features: ${FEATURES}${RESET}"
 
     ARGS=()
-    for feature in $FEATURES; do
+    for feature in $(echo $FEATURES); do
       ARGS+=("-f" "$feature")
     done
 


### PR DESCRIPTION
When we pass several space-separated arguments they are not split (https://github.com/DataDog/datadog-agent/actions/runs/13721504767/job/38377820759). We have the error invalid value 'legacy-tasks legacy-github legacy-release' for '--only-group <ONLY_GROUP>' The iteration on string token does not work on all shell versions. Addition of `echo` in the middle make it more portable