### PR TITLE
Fix the help text of commands that have dynamic parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Fixed:***
 
 - Fix escaping on the non-Windows entry points of prebuilt distributions
+- Fix the help text of commands that have dynamic parameters
 
 ## 0.6.1 - 2025-03-10
 

--- a/src/dda/cli/env/dev/utils.py
+++ b/src/dda/cli/env/dev/utils.py
@@ -24,12 +24,6 @@ def get_env_type(ctx: click.Context, param: click.Option, value: str | None) -> 
     return env_type
 
 
-def option_env_type_callback(ctx: click.Context, param: click.Option, value: str | None) -> str:
-    from dda.cli.env.dev.utils import get_env_type
-
-    return get_env_type(ctx, param, value)
-
-
 option_env_type = partial(
     click.option,
     "--type",
@@ -38,6 +32,6 @@ option_env_type = partial(
     type=click.Choice(AVAILABLE_DEV_ENVS),
     show_default=True,
     is_eager=True,
-    callback=option_env_type_callback,
+    callback=get_env_type,
     help="The type of developer environment",
 )

--- a/src/dda/cli/inv/__init__.py
+++ b/src/dda/cli/inv/__init__.py
@@ -48,7 +48,7 @@ After a dependency is installed once, it will always be available.
     "--help",
     "show_help",
     is_flag=True,
-    help="Show this help message and exit",
+    help="Show this help message and exit.",
 )
 @click.pass_context
 def cmd(


### PR DESCRIPTION
Can be seen with `env dev start -h`