### PR TITLE
Prevent Docker CLI hints/tips output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add initial dependency features for common functionality (`http`, `github`, `gitlab`)
 - Telemetry is now submitted immediately after the command completes rather than a short wait
+- Prevent Docker CLI hints/tips output
 
 ***Fixed:***
 

--- a/src/dda/cli/self/dep/lock/__init__.py
+++ b/src/dda/cli/self/dep/lock/__init__.py
@@ -29,7 +29,6 @@ def cmd(app: Application, *, args: tuple[str, ...]) -> None:
     from packaging.specifiers import SpecifierSet
 
     from dda.utils.fs import Path
-    from dda.utils.process import EnvVars
 
     minor_version: int | None = None
     requires_python = distribution("dda").metadata["Requires-Python"]
@@ -47,23 +46,22 @@ requires-python = "{requires_python}"\
 """
         )
 
-    with EnvVars({"DOCKER_CLI_HINTS": "false"}):
-        app.tools.docker.run([
-            "build",
-            "--build-arg",
-            f"PYTHON_VERSION=3.{minor_version}",
-            "--tag",
-            "dda-lock-deps",
-            "-f",
-            str(resources.files("dda.cli.self.dep.lock").joinpath("Dockerfile")),
-            ".",
-        ])
-        app.tools.docker.run([
-            "run",
-            "--rm",
-            "-t",
-            "-v",
-            f"{Path.cwd()}:/app",
-            "dda-lock-deps",
-            *args,
-        ])
+    app.tools.docker.run([
+        "build",
+        "--build-arg",
+        f"PYTHON_VERSION=3.{minor_version}",
+        "--tag",
+        "dda-lock-deps",
+        "-f",
+        str(resources.files("dda.cli.self.dep.lock").joinpath("Dockerfile")),
+        ".",
+    ])
+    app.tools.docker.run([
+        "run",
+        "--rm",
+        "-t",
+        "-v",
+        f"{Path.cwd()}:/app",
+        "dda-lock-deps",
+        *args,
+    ])

--- a/src/dda/tools/base.py
+++ b/src/dda/tools/base.py
@@ -7,6 +7,8 @@ from abc import ABC, abstractmethod
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, NoReturn
 
+from dda.utils.process import EnvVars
+
 if TYPE_CHECKING:
     from subprocess import CompletedProcess
 
@@ -25,14 +27,32 @@ class Tool(ABC):
     def app(self) -> Application:
         return self.__app
 
+    def env_vars(self) -> dict[str, str]:  # noqa: PLR6301
+        return {}
+
     def wait(self, command: list[str], *args: Any, **kwargs: Any) -> None:
+        self.__populate_env_vars(kwargs)
         self.app.subprocess.wait(self.format_command(command), *args, **kwargs)
 
     def run(self, command: list[str], *args: Any, **kwargs: Any) -> CompletedProcess:
+        self.__populate_env_vars(kwargs)
         return self.app.subprocess.run(self.format_command(command), *args, **kwargs)
 
     def capture(self, command: list[str], *args: Any, **kwargs: Any) -> str:
+        self.__populate_env_vars(kwargs)
         return self.app.subprocess.capture(self.format_command(command), *args, **kwargs)
 
-    def replace_current_process(self, command: list[str], *args: Any, **kwargs: Any) -> NoReturn:
-        self.app.subprocess.replace_current_process(self.format_command(command), *args, **kwargs)
+    def exit_with_command(self, command: list[str], *args: Any, **kwargs: Any) -> NoReturn:
+        self.__populate_env_vars(kwargs)
+        self.app.subprocess.exit_with_command(self.format_command(command), *args, **kwargs)
+
+    def __populate_env_vars(self, kwargs: dict[str, Any]) -> None:
+        env_vars = self.env_vars()
+        if not env_vars:
+            return
+
+        if isinstance(env := kwargs.get("env"), dict):
+            for key, value in env_vars.items():
+                env.setdefault(key, value)
+        else:
+            kwargs["env"] = EnvVars(env_vars)

--- a/src/dda/tools/docker.py
+++ b/src/dda/tools/docker.py
@@ -12,6 +12,9 @@ class Docker(Tool):
     def format_command(self, command: list[str]) -> list[str]:
         return [self.path, *command]
 
+    def env_vars(self) -> dict[str, str]:  # noqa: PLR6301
+        return {"DOCKER_CLI_HINTS": "0"}
+
     @cached_property
     def path(self) -> str:
         import shutil

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -153,7 +153,7 @@ class TestStart:
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
             ),
             (
                 (
@@ -225,7 +225,7 @@ class TestStart:
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
             ),
             (
                 (
@@ -391,7 +391,7 @@ class TestStart:
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
             ),
             (
                 (
@@ -466,7 +466,7 @@ class TestStart:
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
             ),
             (
                 (
@@ -540,7 +540,7 @@ class TestStop:
             """
         )
 
-    def test_default(self, dda, helpers):
+    def test_default(self, dda, helpers, mocker):
         with helpers.hybrid_patch(
             "subprocess.run",
             return_values={
@@ -561,7 +561,7 @@ class TestStop:
         assert calls == [
             (
                 ([helpers.locate("docker"), "stop", "-t", "0", "dda-linux-container-default"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
             ),
         ]
 
@@ -579,7 +579,7 @@ class TestRemove:
             """
         )
 
-    def test_default(self, dda, helpers):
+    def test_default(self, dda, helpers, mocker):
         with helpers.hybrid_patch(
             "subprocess.run",
             return_values={
@@ -602,7 +602,7 @@ class TestRemove:
         assert calls == [
             (
                 ([helpers.locate("docker"), "rm", "-f", "dda-linux-container-default"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
             ),
         ]
 
@@ -614,7 +614,7 @@ class TestShell:
             return_value=CompletedProcess([], returncode=0, stdout=json.dumps([{"State": {"Status": "running"}}])),
         )
         write_server_config = mocker.patch("dda.utils.ssh.write_server_config")
-        replace_current_process = mocker.patch("dda.utils.process.SubprocessRunner.replace_current_process")
+        exit_with_command = mocker.patch("dda.utils.process.SubprocessRunner.exit_with_command")
 
         result = dda("env", "dev", "shell")
 
@@ -629,7 +629,7 @@ class TestShell:
                 "UserKnownHostsFile": "/dev/null",
             },
         )
-        replace_current_process.assert_called_once_with([
+        exit_with_command.assert_called_once_with([
             "ssh",
             "-A",
             "-q",


### PR DESCRIPTION
Annoying text such as this: 
![image](https://github.com/user-attachments/assets/09388a82-299c-4a20-934f-068c9142e489)
