### PR TITLE
Support selecting the architecture for Linux developer environments

### DIFF
--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -49,7 +49,14 @@ class LinuxContainerConfig(DeveloperEnvironmentConfig):
             }
         ),
     ] = "zsh"
-
+    arch: Annotated[
+        Literal["amd64", "arm64"],
+        msgspec.Meta(
+            extra={
+                "help": "The architecture to use e.g. `amd64` or `arm64`",
+            }
+        ),
+    ] = "arm64"
 
 class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -81,7 +88,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
             from dda.utils.retry import wait_for
 
             if not self.config.no_pull:
-                self.docker.wait(["pull", self.config.image], message=f"Pulling image: {self.config.image}")
+                self.docker.wait(["pull", self.config.image, "--platform", f"linux/{self.config.arch}"], message=f"Pulling image: {self.config.image}")
 
             self.shared_dir.ensure_dir()
             command = [
@@ -89,6 +96,8 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 "--pull",
                 "never",
                 "-d",
+                "--platform",
+                f"linux/{self.config.arch}",
                 "--name",
                 self.container_name,
                 "-p",

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn
+from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn, Optional
 
 import msgspec
 
@@ -50,13 +50,14 @@ class LinuxContainerConfig(DeveloperEnvironmentConfig):
         ),
     ] = "zsh"
     arch: Annotated[
-        Literal["amd64", "arm64"],
+        Optional[str],
         msgspec.Meta(
             extra={
                 "help": "The architecture to use e.g. `amd64` or `arm64`",
             }
         ),
-    ] = "arm64"
+    ] = None
+
 
 class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -88,7 +89,10 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
             from dda.utils.retry import wait_for
 
             if not self.config.no_pull:
-                self.docker.wait(["pull", self.config.image, "--platform", f"linux/{self.config.arch}"], message=f"Pulling image: {self.config.image}")
+                pull_command = ["pull", self.config.image]
+                if self.config.arch is not None:
+                    pull_command.extend(["--platform", f"linux/{self.config.arch}"])
+                self.docker.wait(pull_command, message=f"Pulling image: {self.config.image}")
 
             self.shared_dir.ensure_dir()
             command = [
@@ -96,8 +100,6 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 "--pull",
                 "never",
                 "-d",
-                "--platform",
-                f"linux/{self.config.arch}",
                 "--name",
                 self.container_name,
                 "-p",
@@ -107,6 +109,9 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 "-e",
                 AppEnvVars.TELEMETRY_API_KEY,
             ]
+            if self.config.arch is not None:
+                command.extend(["--platform", f"linux/{self.config.arch}"])
+
             for shared_shell_file in self.shell.collect_shared_files():
                 unix_path = shared_shell_file.relative_to(self.global_shared_dir).as_posix()
                 command.extend(("-v", f"{shared_shell_file}:{self.home_dir}/.shared/{unix_path}"))

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn, Optional
+from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn
 
 import msgspec
 
@@ -50,7 +50,7 @@ class LinuxContainerConfig(DeveloperEnvironmentConfig):
         ),
     ] = "zsh"
     arch: Annotated[
-        Optional[str],
+        str | None,
         msgspec.Meta(
             extra={
                 "help": "The architecture to use e.g. `amd64` or `arm64`",
@@ -91,7 +91,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
             if not self.config.no_pull:
                 pull_command = ["pull", self.config.image]
                 if self.config.arch is not None:
-                    pull_command.extend(["--platform", f"linux/{self.config.arch}"])
+                    pull_command.extend(("--platform", f"linux/{self.config.arch}"))
                 self.docker.wait(pull_command, message=f"Pulling image: {self.config.image}")
 
             self.shared_dir.ensure_dir()
@@ -110,7 +110,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 AppEnvVars.TELEMETRY_API_KEY,
             ]
             if self.config.arch is not None:
-                command.extend(["--platform", f"linux/{self.config.arch}"])
+                command.extend(("--platform", f"linux/{self.config.arch}"))
 
             for shared_shell_file in self.shell.collect_shared_files():
                 unix_path = shared_shell_file.relative_to(self.global_shared_dir).as_posix()

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -38,7 +38,7 @@ def test_default_config(app):
     container = LinuxContainer(app=app, name="linux-container", instance="default")
 
     assert msgspec.to_builtins(container.config) == {
-        "arch": "None",
+        "arch": None,
         "cli": "docker",
         "clone": False,
         "image": "datadog/agent-dev-env-linux",

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -38,6 +38,7 @@ def test_default_config(app):
     container = LinuxContainer(app=app, name="linux-container", instance="default")
 
     assert msgspec.to_builtins(container.config) == {
+        "arch": "None",
         "cli": "docker",
         "clone": False,
         "image": "datadog/agent-dev-env-linux",


### PR DESCRIPTION
Add a flag to allow running the dev container with the `amd64` architecture, it relies on `podman`/`docker` `--platform` flag under the hood