### PR TITLE
Auto-enable requirements for KMT tasks

### DIFF
--- a/src/dda/cli/inv/__init__.py
+++ b/src/dda/cli/inv/__init__.py
@@ -79,6 +79,8 @@ def cmd(
             features.append("legacy-test-infra-definitions")
         elif task.startswith("system-probe."):
             features.append("legacy-btf-gen")
+        elif task.startswith("kmt."):
+            features.append("legacy-kernel-matrix-testing")
 
     if no_dynamic_deps:
         import sys


### PR DESCRIPTION
This PR automatically adds the `legacy-kernel-matrix-testing` group when KMT tasks are detected.