### PR TITLE
Prevent passing `TERM` environment variable to SSH connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Prevent passing `TERM` environment variable to SSH connections
+
 ## 0.12.5 - 2025-05-12
 
 ***Fixed:***

--- a/hatch.toml
+++ b/hatch.toml
@@ -7,7 +7,7 @@ dependencies = ["ruff==0.9.9"]
 
 [envs.hatch-test]
 extra-dependencies = [
-  "pyfakefs",
+  "pyfakefs>=5.8.0",
 ]
 
 [envs.types]

--- a/src/dda/env/ssh.py
+++ b/src/dda/env/ssh.py
@@ -8,5 +8,12 @@ def ensure_ssh_config(hostname: str) -> None:
     from dda.utils.ssh import write_server_config
 
     return write_server_config(
-        hostname, {"StrictHostKeyChecking": "no", "ForwardAgent": "yes", "UserKnownHostsFile": "/dev/null"}
+        hostname,
+        {
+            "StrictHostKeyChecking": "no",
+            "ForwardAgent": "yes",
+            "UserKnownHostsFile": "/dev/null",
+            # Prevent passing local config, only supported on OpenSSH 8.7+ https://www.openssh.com/txt/release-8.7
+            "SetEnv": ["TERM=xterm-256color"],
+        },
     )

--- a/src/dda/utils/ssh.py
+++ b/src/dda/utils/ssh.py
@@ -42,11 +42,14 @@ def derive_dynamic_ssh_port(key: str) -> int:
     return repo_id % (max_port - min_port) + min_port
 
 
-def write_server_config(hostname: str, options: dict[str, str]) -> None:
+def write_server_config(hostname: str, options: dict[str, str | list[str]]) -> None:
     config_file = ssh_config_dir() / RELATIVE_CONFIG_DIR / hostname
     lines = [f"Host {hostname}"]
     for key, value in options.items():
-        lines.append(f"    {key} {value}")
+        if isinstance(value, list):
+            lines.extend(f"    {key} {v}" for v in value)
+        else:
+            lines.append(f"    {key} {value}")
 
     lines.append("")
     config_file.parent.ensure_dir()

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -34,6 +34,18 @@ def get_starship_mount(shared_dir: Path) -> list[str]:
     return ["-v", f"{shared_dir / 'shell' / 'starship.toml'}:/root/.shared/shell/starship.toml"]
 
 
+def assert_ssh_config_written(method, hostname):
+    method.assert_called_once_with(
+        hostname,
+        {
+            "StrictHostKeyChecking": "no",
+            "ForwardAgent": "yes",
+            "UserKnownHostsFile": "/dev/null",
+            "SetEnv": ["TERM=xterm-256color"],
+        },
+    )
+
+
 def test_default_config(app):
     container = LinuxContainer(app=app, name="linux-container", instance="default")
 
@@ -140,14 +152,7 @@ class TestStart:
             """
         )
 
-        write_server_config.assert_called_once_with(
-            "localhost",
-            {
-                "StrictHostKeyChecking": "no",
-                "ForwardAgent": "yes",
-                "UserKnownHostsFile": "/dev/null",
-            },
-        )
+        assert_ssh_config_written(write_server_config, "localhost")
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
@@ -212,14 +217,7 @@ class TestStart:
             """
         )
 
-        write_server_config.assert_called_once_with(
-            "localhost",
-            {
-                "StrictHostKeyChecking": "no",
-                "ForwardAgent": "yes",
-                "UserKnownHostsFile": "/dev/null",
-            },
-        )
+        assert_ssh_config_written(write_server_config, "localhost")
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
@@ -302,14 +300,7 @@ class TestStart:
             """
         )
 
-        write_server_config.assert_called_once_with(
-            "localhost",
-            {
-                "StrictHostKeyChecking": "no",
-                "ForwardAgent": "yes",
-                "UserKnownHostsFile": "/dev/null",
-            },
-        )
+        assert_ssh_config_written(write_server_config, "localhost")
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
@@ -378,14 +369,7 @@ class TestStart:
             """
         )
 
-        write_server_config.assert_called_once_with(
-            "localhost",
-            {
-                "StrictHostKeyChecking": "no",
-                "ForwardAgent": "yes",
-                "UserKnownHostsFile": "/dev/null",
-            },
-        )
+        assert_ssh_config_written(write_server_config, "localhost")
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
@@ -453,14 +437,7 @@ class TestStart:
             """
         )
 
-        write_server_config.assert_called_once_with(
-            "localhost",
-            {
-                "StrictHostKeyChecking": "no",
-                "ForwardAgent": "yes",
-                "UserKnownHostsFile": "/dev/null",
-            },
-        )
+        assert_ssh_config_written(write_server_config, "localhost")
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
@@ -625,14 +602,7 @@ class TestShell:
         assert result.exit_code == 0, result.output
         assert not result.output
 
-        write_server_config.assert_called_once_with(
-            "localhost",
-            {
-                "StrictHostKeyChecking": "no",
-                "ForwardAgent": "yes",
-                "UserKnownHostsFile": "/dev/null",
-            },
-        )
+        assert_ssh_config_written(write_server_config, "localhost")
         assert calls == [
             (
                 (
@@ -682,14 +652,7 @@ class TestRun:
         assert result.exit_code == 0, result.output
         assert not result.output
 
-        write_server_config.assert_called_once_with(
-            "localhost",
-            {
-                "StrictHostKeyChecking": "no",
-                "ForwardAgent": "yes",
-                "UserKnownHostsFile": "/dev/null",
-            },
-        )
+        assert_ssh_config_written(write_server_config, "localhost")
         run.assert_called_once_with(
             [
                 "ssh",
@@ -734,14 +697,7 @@ class TestCode:
         assert result.exit_code == 0, result.output
         assert not result.output
 
-        write_server_config.assert_called_once_with(
-            "localhost",
-            {
-                "StrictHostKeyChecking": "no",
-                "ForwardAgent": "yes",
-                "UserKnownHostsFile": "/dev/null",
-            },
-        )
+        assert_ssh_config_written(write_server_config, "localhost")
         run.assert_called_once_with(
             [
                 "code",

--- a/tests/utils/test_ssh.py
+++ b/tests/utils/test_ssh.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import pytest
 
-from dda.utils.ssh import derive_dynamic_ssh_port, ssh_base_command
+from dda.utils.fs import Path
+from dda.utils.ssh import derive_dynamic_ssh_port, ssh_base_command, write_server_config
 
 
 @pytest.mark.parametrize("port", [pytest.param(22, id="int port"), pytest.param("22", id="str port")])
@@ -17,11 +18,21 @@ def test_derive_dynamic_ssh_port() -> None:
     assert 49152 <= derive_dynamic_ssh_port("key") <= 65535
 
 
-# https://github.com/pytest-dev/pyfakefs/issues/1086
-# @pytest.mark.usefixtures("fs")
-# def test_write_server_config() -> None:
-#     hostname = "localhost"
-#     write_server_config(hostname, {"foo": "bar", "baz": "qux"})
+@pytest.mark.usefixtures("fs")
+def test_write_server_config() -> None:
+    hostname = "localhost"
+    write_server_config(hostname, {"foo": "bar", "baz": "qux", "multi": ["a", "b", "c"]})
 
-#     config_file = Path.home() / ".ssh" / ".dda" / hostname
-#     assert config_file.is_file()
+    config_file = Path.home() / ".ssh" / ".dda" / hostname
+    assert config_file.is_file()
+    assert (
+        config_file.read_text()
+        == """\
+Host localhost
+    foo bar
+    baz qux
+    multi a
+    multi b
+    multi c
+"""
+    )


### PR DESCRIPTION
Feedback:

> in my case, I had `TERM=alacritty` and this broke the shell repl, I had to `export TERM=xterm-color` and then `exec zsh` to get backspace/arrow keys working properly