### PR TITLE
Add binary dependency for static quality gates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,10 @@ legacy-test-infra-definitions = [
     "termcolor==2.5.0",
 ]
 
+legacy-static-quality-gates = [
+    "binary==1.0.1"
+]
+
 google-client-api = [
     "google-api-python-client==2.160.0",
     "oauth2client==4.1.3",


### PR DESCRIPTION
Create the `legacy-static-quality-gates` group with the binary dependency required by x64 docker images running static quality gates.
