### PR TITLE
Add `app.tools.go` tool for calling `go` commands with the proper version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Added:***
+
+- Add `app.tools.go` tool for calling `go` commands with the proper version
+
 ## 0.13.1 - 2025-05-28
 
 ***Fixed:***

--- a/docs/reference/api/tools.md
+++ b/docs/reference/api/tools.md
@@ -6,9 +6,14 @@
     options:
       members:
       - docker
+      - go
       - uv
 
 ::: dda.tools.docker.Docker
+    options:
+      members: []
+
+::: dda.tools.go.Go
     options:
       members: []
 

--- a/src/dda/tools/__init__.py
+++ b/src/dda/tools/__init__.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from dda.cli.application import Application
     from dda.tools.docker import Docker
+    from dda.tools.go import Go
     from dda.tools.uv import UV
 
 
@@ -25,6 +26,12 @@ class Tools:
         from dda.tools.docker import Docker
 
         return Docker(self.__app)
+
+    @cached_property
+    def go(self) -> Go:
+        from dda.tools.go import Go
+
+        return Go(self.__app)
 
     @cached_property
     def uv(self) -> UV:

--- a/src/dda/tools/go.py
+++ b/src/dda/tools/go.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from functools import cached_property
+
+from dda.tools.base import Tool
+from dda.utils.fs import Path
+
+
+class Go(Tool):
+    """
+    This will automatically set the [`GOTOOLCHAIN`](https://go.dev/doc/toolchain) environment variable to the proper
+    version based on files in the current directory. The following files are considered, in order of precedence:
+
+    - `.go-version`
+    - `go.mod`
+    - `go.work`
+
+    Example usage:
+
+    ```python
+    app.tools.go.run(["build", "."])
+    ```
+    """
+
+    def format_command(self, command: list[str]) -> list[str]:
+        return [self.path, *command]
+
+    def env_vars(self) -> dict[str, str]:
+        return {"GOTOOLCHAIN": f"go{self.version}"} if self.version else {}
+
+    @cached_property
+    def path(self) -> str:
+        import shutil
+
+        return shutil.which("go") or "go"
+
+    @cached_property
+    def version(self) -> str | None:
+        version_file = Path.cwd() / ".go-version"
+        if version_file.is_file():
+            return version_file.read_text().strip()
+
+        import re
+
+        version_pattern = re.compile(r"^go (.+)", re.MULTILINE)
+
+        mod_file = Path.cwd() / "go.mod"
+        if mod_file.is_file() and (match := version_pattern.search(mod_file.read_text())):
+            return match.group(1)
+
+        work_file = Path.cwd() / "go.work"
+        if work_file.is_file() and (match := version_pattern.search(work_file.read_text())):
+            return match.group(1)
+
+        return None

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/tools/test_go.py
+++ b/tests/tools/test_go.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+
+def test_default(app):
+    assert app.tools.go.env_vars() == {}
+
+
+class TestPrecedence:
+    def test_workspace_file(self, app, temp_dir):
+        (temp_dir / "go.work").write_text("stuff\ngo X.Y.Z\nstuff")
+        with temp_dir.as_cwd():
+            assert app.tools.go.env_vars() == {"GOTOOLCHAIN": "goX.Y.Z"}
+
+    def test_module_file(self, app, temp_dir):
+        (temp_dir / "go.work").write_text("stuff\ngo X.Y.Z\nstuff")
+        (temp_dir / "go.mod").write_text("stuff\ngo X.Y.Zrc1\nstuff")
+        with temp_dir.as_cwd():
+            assert app.tools.go.env_vars() == {"GOTOOLCHAIN": "goX.Y.Zrc1"}
+
+    def test_version_file(self, app, temp_dir):
+        (temp_dir / "go.work").write_text("stuff\ngo X.Y.Z\nstuff")
+        (temp_dir / "go.mod").write_text("stuff\ngo X.Y.Zrc1\nstuff")
+        (temp_dir / ".go-version").write_text("X.Y.Zrc2")
+        with temp_dir.as_cwd():
+            assert app.tools.go.env_vars() == {"GOTOOLCHAIN": "goX.Y.Zrc2"}


### PR DESCRIPTION
I anticipate this reducing toil when pulling the latest commits of the `datadog-agent` repository inside a long-running developer environment. If the version of Go was bumped but your developer image wasn't pulled then you would experience errors.