### PR TITLE
Add Git author details to telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Added:***
 
 - Add `app.tools.go` tool for calling `go` commands with the proper version
+- Add Git author details to telemetry
 
 ## 0.13.1 - 2025-05-28
 

--- a/src/dda/cli/base.py
+++ b/src/dda/cli/base.py
@@ -140,6 +140,8 @@ class DynamicContext(click.RichContext):
             metadata = {
                 "cli.command": join_command_args(sys.argv[1:]),
                 "cli.exit_code": str(exit_code),
+                "git.author.name": app.config.git.user.name,
+                "git.author.email": app.config.git.user.email,
             }
             if last_error := app.last_error.strip():
                 # Payload limit is 5MB so we truncate the error message to a little bit less than that


### PR DESCRIPTION
This will start working properly after https://github.com/DataDog/datadog-agent-buildimages/pull/854