### PR TITLE
add jinja2 to the list of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "find-exe~=0.1",
   "httpx[http2]~=0.28.1",
   "hvac~=2.3.0",
-  "jinja2~=3.1.6",
   "keyring~=25.6.0",
   "msgspec~=0.18",
   "msgspec-click~=0.2",
@@ -82,6 +81,7 @@ legacy-build = [
     "docker==6.1.3",
     "dulwich==0.21.6",
     "invoke==2.2.0",
+    "jinja2~=3.1.6",
     "mypy==1.10.0",
     # https://github.com/pypa/setuptools/issues/4501
     "packaging==25.0",

--- a/uv.lock
+++ b/uv.lock
@@ -413,6 +413,7 @@ legacy-build = [
     { name = "docker-squash" },
     { name = "dulwich" },
     { name = "invoke" },
+    { name = "jinja2" },
     { name = "mypy" },
     { name = "packaging" },
     { name = "parameterized" },
@@ -471,7 +472,6 @@ legacy-github = [
     { name = "toml" },
 ]
 legacy-kernel-matrix-testing = [
-    { name = "jinja2" },
     { name = "libvirt-python" },
     { name = "python-levenshtein" },
     { name = "termcolor" },
@@ -507,6 +507,7 @@ legacy-tasks = [
     { name = "docker-squash" },
     { name = "dulwich" },
     { name = "invoke" },
+    { name = "jinja2" },
     { name = "linkchecker" },
     { name = "lxml" },
     { name = "mkdocs" },
@@ -607,6 +608,7 @@ legacy-build = [
     { name = "docker-squash", specifier = "==1.1.0" },
     { name = "dulwich", specifier = "==0.21.6" },
     { name = "invoke", specifier = "==2.2.0" },
+    { name = "jinja2", specifier = "~=3.1.6" },
     { name = "mypy", specifier = "==1.10.0" },
     { name = "packaging", specifier = "==25.0" },
     { name = "parameterized", specifier = "==0.9.0" },
@@ -663,7 +665,6 @@ legacy-github = [
     { name = "toml", specifier = "~=0.10.2" },
 ]
 legacy-kernel-matrix-testing = [
-    { name = "jinja2", specifier = "==3.0.3" },
     { name = "libvirt-python", specifier = "==10.9.0" },
     { name = "python-levenshtein", specifier = "==0.26.1" },
     { name = "termcolor", specifier = "==2.5.0" },
@@ -697,6 +698,7 @@ legacy-tasks = [
     { name = "docker-squash", specifier = "==1.1.0" },
     { name = "dulwich", specifier = "==0.21.6" },
     { name = "invoke", specifier = "==2.2.0" },
+    { name = "jinja2", specifier = "~=3.1.6" },
     { name = "linkchecker", specifier = "~=10.5.0" },
     { name = "lxml", specifier = "~=5.2.2" },
     { name = "mkdocs", specifier = "~=1.5.3" },
@@ -1206,14 +1208,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.0.3"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/a5/429efc6246119e1e3fbf562c00187d04e83e54619249eb732bb423efa6c6/Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7", size = 269196, upload-time = "2021-11-09T20:27:29.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/9a/e5d9ec41927401e41aea8af6d16e78b5e612bca4699d417f646a9610a076/Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8", size = 133630, upload-time = "2021-11-09T20:27:27.116Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
in order to make https://github.com/DataDog/datadog-agent/pull/37602 possible, this PR adds `jinja2` in the list of dependencies.

Since the dependency is now in the main "bundle", this PR also removes it from `legacy-kernel-matrix-testing`