### PR TITLE
Add quotes around executable path on Windows, add test for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Fixed:***
 
 - Workaround a limitation of the PTY dependency on Windows
+- Properly handle executable paths with spaces on Windows when using a pseudo-terminal
 
 ## 0.14.0 - 2025-05-30
 

--- a/src/dda/utils/platform/_pty/windows.py
+++ b/src/dda/utils/platform/_pty/windows.py
@@ -40,7 +40,8 @@ class PtySession(PtySessionInterface):
         width, height = self.get_terminal_dimensions()
         self.pty = winpty.PTY(width, height)
         self.pty.spawn(
-            f'"{self.executable}"',
+            # Add quotes if the executable path contains spaces
+            join_command_args([self.executable]),
             cmdline=join_command_args(self.args) if self.args else None,
             cwd=self.cwd,
             env=(

--- a/src/dda/utils/platform/_pty/windows.py
+++ b/src/dda/utils/platform/_pty/windows.py
@@ -40,7 +40,7 @@ class PtySession(PtySessionInterface):
         width, height = self.get_terminal_dimensions()
         self.pty = winpty.PTY(width, height)
         self.pty.spawn(
-            self.executable,
+            f'"{self.executable}"',
             cmdline=join_command_args(self.args) if self.args else None,
             cwd=self.cwd,
             env=(

--- a/tests/utils/test_process.py
+++ b/tests/utils/test_process.py
@@ -86,7 +86,7 @@ f.write_text("foo")
         assert output_file.read_text() == "foo"
 
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows only test")
-    def test_executable_with_spaces(self, app):
+    def test_executable_with_spaces(self, app, temp_dir):
         # Windows Defender executable path which contains spaces
         executable = Path("C:\\Program Files\\Windows Defender\\MpCmdRun.exe")
 
@@ -94,8 +94,12 @@ f.write_text("foo")
         if not executable.exists():
             pytest.skip(f"Test executable not found: {executable}")
 
-        # Run a simple command that exits quickly (-h shows help)
-        output = app.subprocess.capture([str(executable), "-h"], show=True)
+        # Use a temporary directory to avoid strange permission errors
+        with temp_dir.as_cwd():
+            # Run a simple command that exits quickly (-h shows help)
+            # Enable replayed output so that the PTY logic is used
+            output = app.subprocess.capture([str(executable), "-h"], show=True)
+
         assert "Microsoft Antimalware Service" in output
 
     def test_run_reverse_interactivity(self, app, mocker, tmp_path):

--- a/tests/utils/test_process.py
+++ b/tests/utils/test_process.py
@@ -89,13 +89,13 @@ f.write_text("foo")
     def test_executable_with_spaces(self, app):
         # Windows Defender executable path which contains spaces
         executable = Path("C:\\Program Files\\Windows Defender\\MpCmdRun.exe")
-        
+
         # Skip if the executable doesn't exist (some Windows versions might not have it)
         if not executable.exists():
             pytest.skip(f"Test executable not found: {executable}")
-        
+
         # Run a simple command that exits quickly (-h shows help)
-        output = app.subprocess.capture([str(executable), "-h"])
+        output = app.subprocess.capture([str(executable), "-h"], show=True)
         assert "Microsoft Antimalware Service" in output
 
     def test_run_reverse_interactivity(self, app, mocker, tmp_path):

--- a/tests/utils/test_process.py
+++ b/tests/utils/test_process.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -83,6 +84,19 @@ f.write_text("foo")
         app.subprocess.run([sys.executable, "-c", script])
         assert output_file.is_file()
         assert output_file.read_text() == "foo"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows only test")
+    def test_executable_with_spaces(self, app):
+        # Windows Defender executable path which contains spaces
+        executable = Path("C:\\Program Files\\Windows Defender\\MpCmdRun.exe")
+        
+        # Skip if the executable doesn't exist (some Windows versions might not have it)
+        if not executable.exists():
+            pytest.skip(f"Test executable not found: {executable}")
+        
+        # Run a simple command that exits quickly (-h shows help)
+        output = app.subprocess.capture([str(executable), "-h"])
+        assert "Microsoft Antimalware Service" in output
 
     def test_run_reverse_interactivity(self, app, mocker, tmp_path):
         if app.console.is_interactive:

--- a/tests/utils/test_process.py
+++ b/tests/utils/test_process.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
 
 import pytest
 
@@ -88,17 +87,17 @@ f.write_text("foo")
     @pytest.mark.skipif(sys.platform != "win32", reason="Windows only test")
     def test_executable_with_spaces(self, app, temp_dir):
         # Windows Defender executable path which contains spaces
-        executable = Path("C:\\Program Files\\Windows Defender\\MpCmdRun.exe")
+        executable = "C:\\Program Files\\Windows Defender\\MpCmdRun.exe"
 
         # Skip if the executable doesn't exist (some Windows versions might not have it)
-        if not executable.exists():
+        if not os.path.exists(executable):
             pytest.skip(f"Test executable not found: {executable}")
 
         # Use a temporary directory to avoid strange permission errors
         with temp_dir.as_cwd():
             # Run a simple command that exits quickly (-h shows help)
             # Enable replayed output so that the PTY logic is used
-            output = app.subprocess.capture([str(executable), "-h"], show=True)
+            output = app.subprocess.capture([executable, "-h"], show=True)
 
         assert "Microsoft Antimalware Service" in output
 


### PR DESCRIPTION
This PR adds quotes around the executable passed to `pty.spawn` on Windows, this is to prevent an issue with spaces causing the cryptic `%1 is not a valid Win32 application.`.
I have also added a test that shows that the fix is working - tested by restoring the original, unquoted executable and verifying the test failed.