### PR TITLE
Ensure all Windows jobs use a non-deprecated runner

### DIFF
--- a/.github/workflows/build-distributions.yml
+++ b/.github/workflows/build-distributions.yml
@@ -137,7 +137,7 @@ jobs:
       matrix:
         job:
         - target: x86_64-pc-windows-msvc
-          os: windows-2019
+          os: windows-2022
         - target: aarch64-apple-darwin
           os: macos-14
         - target: x86_64-apple-darwin


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/12045