### PR TITLE
Fix telemetry for the `inv` command when using root `dda` flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Fix telemetry for the `inv` command when using root `dda` flags
+
 ## 0.15.0 - 2025-06-03
 
 ***Added:***

--- a/src/dda/cli/base.py
+++ b/src/dda/cli/base.py
@@ -150,9 +150,14 @@ class DynamicContext(click.RichContext):
 
             resource = " ".join(root_ctx.deepest_command_path.split()[1:])
             if resource == "inv":
+                try:
+                    command_start = sys.argv.index("inv")
+                except ValueError:  # no cov
+                    command_start = 1
+
                 # Accumulate leading non-flag arguments to the resource
                 command_parts: list[str] = []
-                for arg in sys.argv[1:]:
+                for arg in sys.argv[command_start:]:
                     if len(command_parts) == 1 and arg in {"--", "-e", "--echo"}:
                         continue
                     # A real flag


### PR DESCRIPTION
Before and after:

![image](https://github.com/user-attachments/assets/84a5b707-9212-4b29-9768-01ae78511d43)