### PR TITLE
Fix automatic feature detection for the `inv` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Fixed:***
 
 - Fix telemetry for the `inv` command when using root `dda` flags
+- Fix dynamic dependency installation for the `inv` command for a newly deprecated feature flag
 
 ## 0.15.0 - 2025-06-03
 

--- a/src/dda/cli/inv/__init__.py
+++ b/src/dda/cli/inv/__init__.py
@@ -65,12 +65,8 @@ def cmd(
 
     features = ["legacy-tasks", *extra_features]
     invoke_args = [arg for arg in args if not arg.startswith("-")]
-    if invoke_args:
-        task = invoke_args[0]
-        if Path.cwd().name == "test-infra-definitions":
-            features.append("legacy-test-infra-definitions")
-        elif task.startswith("system-probe."):
-            features.append("legacy-btf-gen")
+    if invoke_args and Path.cwd().name == "test-infra-definitions":
+        features.append("legacy-test-infra-definitions")
 
     if no_dynamic_deps:
         import sys


### PR DESCRIPTION
The feature was removed because it no longer served a purpose https://github.com/DataDog/datadog-agent-dev/pull/112