### PR TITLE
Persist cache directories for the Linux dev env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Added:***
+
+- Persist cache directories for the `linux-container` developer environment type
+
 ## 0.15.1 - 2025-06-05
 
 ***Fixed:***

--- a/docs/reference/api/container/model.md
+++ b/docs/reference/api/container/model.md
@@ -1,0 +1,7 @@
+# Container model reference
+
+-----
+
+::: dda.utils.container.model.Mount
+    options:
+      show_if_no_docstring: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,8 @@ nav:
     - Tools: reference/api/tools.md
     - CI: reference/api/ci.md
     - Config: reference/api/config.md
+    - Container:
+      - Model: reference/api/container/model.md
     - Constants: reference/api/constants.md
     - Telemetry: reference/api/telemetry.md
   - Interface:

--- a/src/dda/utils/container/__init__.py
+++ b/src/dda/utils/container/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/src/dda/utils/container/model.py
+++ b/src/dda/utils/container/model.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import sys
+from typing import Literal
+
+from msgspec import Struct
+
+from dda.utils.fs import Path
+
+
+class Mount(Struct):
+    """
+    This represents [mount configuration](https://docs.docker.com/engine/storage/volumes/#options-for---mount)
+    for a container.
+    """
+
+    type: Literal["bind", "volume"]
+    """
+    The type of mount, either [`bind`](https://docs.docker.com/engine/storage/bind-mounts/) or
+    [`volume`](https://docs.docker.com/engine/storage/volumes/).
+    """
+    path: str
+    """
+    The path where the file or directory is mounted in the container.
+    """
+    source: str | None = None
+    """
+    For bind mounts, this is the path to the file or directory on the host. For volume mounts, this is
+    the name of the volume. Anonymous volumes must not set this.
+    """
+    read_only: bool = False
+    """
+    Whether the mount is read-only.
+    """
+    volume_options: dict[str, str] = {}
+    """
+    Additional options for the `volume` mounts.
+    """
+
+    def __post_init__(self) -> None:
+        if self.type == "bind":
+            if self.source is None:
+                msg = "source is required for bind mounts"
+                raise ValueError(msg)
+
+            # https://docs.docker.com/desktop/troubleshoot-and-support/troubleshoot/topics/#path-conversion-errors-on-windows
+            if sys.platform == "win32":
+                path = Path(self.source)
+                if path.is_absolute():
+                    drive_letter = path.drive.replace(":", "").lower()
+                    self.source = f"/{path.as_posix().replace(path.drive, drive_letter, 1)}"
+
+    def as_csv(self) -> str:
+        """
+        This returns a CSV representation of the mount configuration. This can be used directly by the
+        `--mount` flag of the `docker run` command.
+        """
+        import csv
+        from io import StringIO
+
+        with StringIO() as s:
+            columns = [f"type={self.type}"]
+            if self.source is not None:
+                columns.append(f"src={self.source}")
+
+            columns.append(f"dst={self.path}")
+            if self.read_only:
+                columns.append("ro")
+            if self.volume_options:
+                for option, value in self.volume_options.items():
+                    columns.append(f"volume-opt={option}={value}")
+
+            writer = csv.writer(s)
+            writer.writerow(columns)
+            return s.getvalue().rstrip()

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -34,6 +34,27 @@ def get_starship_mount(shared_dir: Path) -> list[str]:
     return ["-v", f"{shared_dir / 'shell' / 'starship.toml'}:/root/.shared/shell/starship.toml"]
 
 
+def get_cache_volumes() -> list[str]:
+    return [
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-go_build_cache,dst=/root/.cache/go-build",
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-go_mod_cache,dst=/go/pkg/mod",
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-pip_cache,dst=/root/.cache/pip",
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-cargo_registry,dst=/root/.cargo/registry",
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-cargo_git,dst=/root/.cargo/git",
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-omnibus_gems,dst=/omnibus/vendor/bundle",
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-omnibus_cache,dst=/omnibus/cache",
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-omnibus_git_cache,dst=/tmp/omnibus-git-cache",
+    ]
+
+
 def assert_ssh_config_written(method, hostname):
     method.assert_called_once_with(
         hostname,
@@ -156,6 +177,7 @@ class TestStart:
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
+        cache_volumes = get_cache_volumes()
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
@@ -186,6 +208,7 @@ class TestStart:
                         *starship_mount,
                         "-v",
                         f"{shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
+                        *cache_volumes,
                         "-v",
                         f"{repo_dir}:/root/repos/datadog-agent",
                         "datadog/agent-dev-env-linux",
@@ -227,6 +250,7 @@ class TestStart:
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
+        cache_volumes = get_cache_volumes()
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
@@ -257,6 +281,7 @@ class TestStart:
                         *starship_mount,
                         "-v",
                         f"{shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
+                        *cache_volumes,
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
@@ -316,6 +341,7 @@ class TestStart:
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
+        cache_volumes = get_cache_volumes()
         assert calls == [
             (
                 (
@@ -342,6 +368,7 @@ class TestStart:
                         *starship_mount,
                         "-v",
                         f"{shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
+                        *cache_volumes,
                         "-v",
                         f"{repo_dir}:/root/repos/datadog-agent",
                         "datadog/agent-dev-env-linux",
@@ -391,6 +418,7 @@ class TestStart:
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
+        cache_volumes = get_cache_volumes()
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
@@ -421,6 +449,7 @@ class TestStart:
                         *starship_mount,
                         "-v",
                         f"{shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
+                        *cache_volumes,
                         "-v",
                         f"{repo1_dir}:/root/repos/datadog-agent",
                         "-v",
@@ -465,6 +494,7 @@ class TestStart:
 
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / ".shared"
         starship_mount = get_starship_mount(shared_dir)
+        cache_volumes = get_cache_volumes()
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
@@ -495,6 +525,7 @@ class TestStart:
                         *starship_mount,
                         "-v",
                         f"{shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
+                        *cache_volumes,
                         "datadog/agent-dev-env-linux",
                     ],
                 ),

--- a/tests/utils/container/__init__.py
+++ b/tests/utils/container/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/tests/utils/container/test_model.py
+++ b/tests/utils/container/test_model.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from dda.utils.container.model import Mount
+
+
+class TestMount:
+    def test_bind_without_source(self):
+        with pytest.raises(ValueError, match="source is required for bind mounts"):
+            Mount(type="bind", path="target")
+
+    def test_anonymous_volume(self):
+        mount = Mount(type="volume", path="target")
+        assert mount.as_csv() == "type=volume,dst=target"
+
+    def test_named_volume(self):
+        mount = Mount(type="volume", path="target", source="volume_name")
+        assert mount.as_csv() == "type=volume,src=volume_name,dst=target"
+
+    def test_named_volume_with_options(self):
+        mount = Mount(type="volume", path="target", source="volume_name", volume_options={"foo": "bar", "baz": "qux"})
+        assert mount.as_csv() == "type=volume,src=volume_name,dst=target,volume-opt=foo=bar,volume-opt=baz=qux"
+
+    def test_read_only(self):
+        mount = Mount(type="bind", path="target", source="source", read_only=True)
+        assert mount.as_csv() == "type=bind,src=source,dst=target,ro"
+
+    def test_quoting(self):
+        mount = Mount(type="bind", path="target", source="foo,bar")
+        assert mount.as_csv() == 'type=bind,"src=foo,bar",dst=target'
+
+    def test_quoting_with_escaping(self):
+        mount = Mount(type="bind", path='foo"bar', source='foo,bar"baz')
+        assert mount.as_csv() == 'type=bind,"src=foo,bar""baz","dst=foo""bar"'
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_bind_mount_on_windows(self):
+        mount = Mount(type="bind", path="target", source="C:\\Users\\foo")
+        assert mount.as_csv() == "type=bind,src=/c/Users/foo,dst=target"


### PR DESCRIPTION
I tried to use one volume with multiple `volume-subpath` [options](https://docs.docker.com/engine/storage/volumes/#options-for---mount) but each sub path is required to exist so there has to be an initial step of starting a container just to create the directories which doesn't seem worth it.