### PR TITLE
Persist VS Code extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Added:***
+
+- Persist the VS Code extensions directory in the cache for the `linux-container` developer environment type
+
 ## 0.16.0 - 2025-06-12
 
 ***Added:***

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -323,6 +323,8 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 path="/tmp/omnibus-git-cache",  # noqa: S108
                 source=self.get_volume_name("omnibus_git_cache"),
             ),
+            # VS Code/Cursor
+            Mount(type="volume", path="/root/.vscode-extensions", source=self.get_volume_name("vscode_extensions")),
         ]
 
     def cache_volume_names(self) -> list[str]:

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -52,6 +52,8 @@ def get_cache_volumes() -> list[str]:
         "type=volume,src=dda-env-dev-linux-container-omnibus_cache,dst=/omnibus/cache",
         "--mount",
         "type=volume,src=dda-env-dev-linux-container-omnibus_git_cache,dst=/tmp/omnibus-git-cache",
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-vscode_extensions,dst=/root/.vscode-extensions",
     ]
 
 


### PR DESCRIPTION
The shared directory was introduced in https://github.com/DataDog/datadog-agent-buildimages/pull/873