### PR TITLE
Make the code editor configurable for developer environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Added:***
 
 - Persist the VS Code extensions directory in the cache for the `linux-container` developer environment type
+- Make the editor configurable for the `code` method of the `linux-container` developer environment type
+- Add `--editor`/`-e` flag to the `env dev code` command
 
 ## 0.16.0 - 2025-06-12
 

--- a/src/dda/config/model/env.py
+++ b/src/dda/config/model/env.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from msgspec import Struct, field
 
 from dda.env.dev import DEFAULT_DEV_ENV
+from dda.utils.editors import AVAILABLE_EDITORS, DEFAULT_EDITOR
 
 
 class DevEnvConfig(Struct, frozen=True):
@@ -16,6 +17,7 @@ class DevEnvConfig(Struct, frozen=True):
     default-type = "linux-container"
     clone-repos = false
     universal-shell = false
+    editor = "vscode"
     ```
     ///
     """
@@ -23,6 +25,12 @@ class DevEnvConfig(Struct, frozen=True):
     default_type: str = field(name="default-type", default=DEFAULT_DEV_ENV)
     clone_repos: bool = field(name="clone-repos", default=False)
     universal_shell: bool = field(name="universal-shell", default=False)
+    editor: str = DEFAULT_EDITOR
+
+    def __post_init__(self) -> None:
+        if self.editor not in AVAILABLE_EDITORS:
+            message = f"Unknown editor `{self.editor}`, must be one of: {', '.join(AVAILABLE_EDITORS)}"
+            raise ValueError(message)
 
 
 class EnvConfig(Struct, frozen=True):

--- a/src/dda/env/dev/interface.py
+++ b/src/dda/env/dev/interface.py
@@ -9,6 +9,9 @@ from typing import TYPE_CHECKING, Annotated, Generic, NoReturn, cast
 
 import msgspec
 
+if TYPE_CHECKING:
+    from dda.utils.editors.interface import EditorInterface
+
 
 class DeveloperEnvironmentConfig(msgspec.Struct, kw_only=True):
     repos: Annotated[
@@ -123,13 +126,14 @@ class DeveloperEnvironmentInterface(ABC, Generic[ConfigT]):
         """
 
     @abstractmethod
-    def code(self, *, repo: str | None = None) -> None:
+    def code(self, *, editor: EditorInterface, repo: str | None = None) -> None:
         """
         This method opens the developer environment's code in the configured editor.
 
         Users trigger this method by running the [`env dev code`](../../../cli/commands.md#dda-env-dev-code) command.
 
         Parameters:
+            editor: The editor to use.
             repo: The repository to open the code for, or `None` to open the code for the first
                 [configured repository][dda.env.dev.interface.DeveloperEnvironmentConfig.repos].
         """

--- a/src/dda/utils/editors/__init__.py
+++ b/src/dda/utils/editors/__init__.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from dda.utils.editors.interface import EditorInterface
+
+
+def get_editor(env_type: str) -> type[EditorInterface]:
+    getter = __EDITORS.get(env_type)
+    if getter is None:  # no cov
+        message = f"Unknown editor `{env_type}`, must be one of: {', '.join(AVAILABLE_EDITORS)}"
+        raise ValueError(message)
+
+    return getter()
+
+
+def __get_vscode() -> type[EditorInterface]:
+    from dda.utils.editors.types.vscode import VSCodeEditorInterface
+
+    return VSCodeEditorInterface
+
+
+def __get_cursor() -> type[EditorInterface]:
+    from dda.utils.editors.types.cursor import CursorEditorInterface
+
+    return CursorEditorInterface
+
+
+__EDITORS: dict[str, Callable[[], type[EditorInterface]]] = {
+    "vscode": __get_vscode,
+    "cursor": __get_cursor,
+}
+
+AVAILABLE_EDITORS: list[str] = sorted(__EDITORS)
+DEFAULT_EDITOR = "vscode"

--- a/src/dda/utils/editors/interface.py
+++ b/src/dda/utils/editors/interface.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+class EditorInterface(ABC):
+    """
+    This interface defines the behavior of a code editor.
+    """
+
+    def __init__(self, *, app: Application, name: str) -> None:
+        self.__app = app
+        self.__name = name
+
+    @property
+    def app(self) -> Application:
+        return self.__app
+
+    @property
+    def name(self) -> str:
+        return self.__name
+
+    @abstractmethod
+    def open_via_ssh(self, *, server: str, port: int, path: str) -> None:
+        """
+        Open the editor via SSH.
+
+        Parameters:
+            server: The server to connect to.
+            port: The port to connect to.
+            path: The path to the repository to open.
+        """

--- a/src/dda/utils/editors/types/__init__.py
+++ b/src/dda/utils/editors/types/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/src/dda/utils/editors/types/cursor.py
+++ b/src/dda/utils/editors/types/cursor.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from dda.utils.editors.interface import EditorInterface
+
+
+class CursorEditorInterface(EditorInterface):
+    def open_via_ssh(self, *, server: str, port: int, path: str) -> None:
+        self.app.subprocess.run(["cursor", "--remote", f"ssh-remote+root@{server}:{port}", path])

--- a/src/dda/utils/editors/types/vscode.py
+++ b/src/dda/utils/editors/types/vscode.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from dda.utils.editors.interface import EditorInterface
+
+
+class VSCodeEditorInterface(EditorInterface):
+    def open_via_ssh(self, *, server: str, port: int, path: str) -> None:
+        self.app.subprocess.run(["code", "--remote", f"ssh-remote+root@{server}:{port}", path])

--- a/tests/cli/config/test_show.py
+++ b/tests/cli/config/test_show.py
@@ -24,6 +24,7 @@ def test_default_scrubbed(dda, config_file, helpers, default_cache_dir, default_
         default-type = "{DEFAULT_DEV_ENV}"
         clone-repos = false
         universal-shell = false
+        editor = "vscode"
 
         [storage]
         data = "{default_data_directory}"
@@ -70,6 +71,7 @@ def test_reveal(dda, config_file, helpers, default_cache_dir, default_data_dir):
         default-type = "{DEFAULT_DEV_ENV}"
         clone-repos = false
         universal-shell = false
+        editor = "vscode"
 
         [storage]
         data = "{default_data_directory}"

--- a/tests/env/dev/test_interface.py
+++ b/tests/env/dev/test_interface.py
@@ -3,13 +3,16 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-from typing import NoReturn
+from typing import TYPE_CHECKING, NoReturn
 
 import msgspec
 import pytest
 
 from dda.env.dev.interface import DeveloperEnvironmentConfig, DeveloperEnvironmentInterface
 from dda.env.models import EnvironmentState, EnvironmentStatus
+
+if TYPE_CHECKING:
+    from dda.utils.editors.interface import EditorInterface
 
 pytestmark = [pytest.mark.usefixtures("private_storage")]
 
@@ -26,7 +29,7 @@ class Container(DeveloperEnvironmentInterface):
 
     def launch_shell(self, *, repo: str | None = None) -> NoReturn: ...
 
-    def code(self, *, repo: str | None = None) -> None: ...
+    def code(self, *, editor: EditorInterface, repo: str | None = None) -> None: ...
 
     def run_command(self, command: list[str], *, repo: str | None = None) -> None: ...
 


### PR DESCRIPTION
Many of us now use Cursor and we will soon support JetBrains IDEs.

Default to Cursor with:

```
dda config set env.dev.editor cursor
```