### PR TITLE
[ACIX-889] Add `--repo` flag to `inv` subcommand

### DIFF
--- a/docs/reference/api/fs.md
+++ b/docs/reference/api/fs.md
@@ -4,6 +4,8 @@
 
 ::: dda.utils.fs.temp_directory
 
+::: dda.utils.fs.change_workdir
+
 ::: dda.utils.fs.Path
     options:
       show_bases: true

--- a/src/dda/cli/inv/__init__.py
+++ b/src/dda/cli/inv/__init__.py
@@ -24,8 +24,7 @@ if TYPE_CHECKING:
     "extra_features",
     multiple=True,
     help="""\
-Extra features to install (multiple allowed).
-After a feature is installed once, it will always be available.
+Extra features to install (multiple allowed). After a feature is installed once, it will always be available.
 """,
 )
 @click.option(
@@ -33,23 +32,21 @@ After a feature is installed once, it will always be available.
     "extra_dependencies",
     multiple=True,
     help="""\
-Extra dependencies to install (multiple allowed).
-After a dependency is installed once, it will always be available.
+Extra dependencies to install (multiple allowed). After a dependency is installed once, it will always be available.
 """,
 )
 @click.option(
     "--repo",
     type=click.Path(exists=True, file_okay=False, dir_okay=True, resolve_path=True),
     help="""\
-Allows running invoke task from another repository than the one in the current working directory.
-Pass in a path to a local clone of this other repository.
+Allows running invoke task from another repository than the one in the current working directory. Pass in a path to a local clone of this other repository.
 """,
 )
 @click.option(
     "--no-dynamic-deps",
     envvar=AppEnvVars.NO_DYNAMIC_DEPS,
     is_flag=True,
-    help="Assume required dependencies are already installed",
+    help="Assume required dependencies are already installed.",
 )
 @click.pass_context
 def cmd(

--- a/src/dda/cli/inv/__init__.py
+++ b/src/dda/cli/inv/__init__.py
@@ -96,8 +96,6 @@ def cmd(
                 prefix=str(venv.path),
             )
             if extra_dependencies:
-                ensure_deps_installed(
-                    list(extra_dependencies), app=app, sys_path=venv.get_sys_path(app)
-                )
+                ensure_deps_installed(list(extra_dependencies), app=app, sys_path=venv.get_sys_path(app))
 
             app.subprocess.exit_with(["python", "-m", "invoke", *args])

--- a/src/dda/utils/fs.py
+++ b/src/dda/utils/fs.py
@@ -137,3 +137,27 @@ def temp_directory() -> Generator[Path, None, None]:
 
     with TemporaryDirectory() as d:
         yield Path(d).resolve()
+
+
+@contextmanager
+def change_workdir(new_workdir: Path) -> Generator[None, None, None]:
+    """
+    A context manager that temporarily changes the current working directory to the specified path.
+    Example:
+
+    ```python
+    with change_workdir("foo"):
+        ...
+    ```
+
+    Yields:
+        None
+    """
+    new_workdir = Path(new_workdir).expand()
+    old_workdir = Path.cwd().expand()
+    os.chdir(new_workdir)
+
+    try:
+        yield
+    finally:
+        os.chdir(old_workdir)

--- a/src/dda/utils/fs.py
+++ b/src/dda/utils/fs.py
@@ -142,16 +142,12 @@ def temp_directory() -> Generator[Path, None, None]:
 @contextmanager
 def change_workdir(new_workdir: Path) -> Generator[None, None, None]:
     """
-    A context manager that temporarily changes the current working directory to the specified path.
-    Example:
+    A context manager that temporarily selects the specified path as the working directory. Example:
 
     ```python
     with change_workdir("foo"):
         ...
     ```
-
-    Yields:
-        None
     """
     new_workdir = Path(new_workdir).expand()
     old_workdir = Path.cwd().expand()


### PR DESCRIPTION
This new flag for the `inv` subcommand allows a user to run an invoke task from another repo than the one in his current working directory.
This can be useful for example for running an invoke task from `test-infra-definitions` while in a local checkout of `datadog-agent`