### PR TITLE
Add MCP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Added:***
+
+- Add MCP support for the `dda` command
+- The `app.subprocess.spawn_daemon` method now returns the PID of the spawned process
+
 ## 0.17.0 - 2025-06-17
 
 ***Added:***

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "psutil~=7.0",
   "pywinpty~=2.0.15; sys_platform == 'win32'",
   "rich~=14.0",
-  "rich-click~=1.8",
+  "rich-click~=1.8.9",
   "tomlkit~=0.13",
   "truststore~=0.10.1",
   # https://peps.python.org/pep-0696/
@@ -56,11 +56,18 @@ self-dev = [
 http = [
     "httpx[zstd]",
 ]
+gcp = [
+    "google-api-python-client~=2.160.0",
+    "oauth2client~=4.1.3",
+]
 github = [
     "pygithub",
 ]
 gitlab = [
     "python-gitlab",
+]
+mcp = [
+    "pycli-mcp~=0.3.0",
 ]
 ### The following dependencies were defined in the build image repo
 # https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements/constraints.txt
@@ -187,11 +194,6 @@ legacy-test-infra-definitions = [
     "pyperclip==1.9.0",
     "pyright==1.1.391",
     "termcolor==2.5.0",
-]
-
-gcp = [
-    "google-api-python-client==2.160.0",
-    "oauth2client==4.1.3",
 ]
 
 [project.urls]

--- a/src/dda/cli/base.py
+++ b/src/dda/cli/base.py
@@ -143,6 +143,9 @@ class DynamicContext(click.RichContext):
                 "git.author.name": app.config.git.user.name,
                 "git.author.email": app.config.git.user.email,
             }
+            if mcp_tool_name := os.environ.get("PYCLI_MCP_TOOL_NAME"):
+                metadata["mcp.tool.name"] = mcp_tool_name
+
             if last_error := app.last_error.strip():
                 # Payload limit is 5MB so we truncate the error message to a little bit less than that
                 message_max_length = int(1024 * 1024 * 4.5)

--- a/src/dda/cli/self/mcp_server/__init__.py
+++ b/src/dda/cli/self/mcp_server/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from dda.cli.base import dynamic_group
+
+
+@dynamic_group(
+    short_help="Manage the MCP server",
+)
+def cmd() -> None:
+    pass

--- a/src/dda/cli/self/mcp_server/log/__init__.py
+++ b/src/dda/cli/self/mcp_server/log/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dda.cli.base import dynamic_command, pass_app
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+@dynamic_command(short_help="Display the MCP server log")
+@pass_app
+def cmd(app: Application) -> None:
+    """
+    Display the MCP server log.
+    """
+    from dda.mcp.manager import MCPManager
+
+    manager = MCPManager(app)
+    manager.show_log()

--- a/src/dda/cli/self/mcp_server/start/__init__.py
+++ b/src/dda/cli/self/mcp_server/start/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+from dda.cli.base import dynamic_command, pass_app
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+@dynamic_command(short_help="Start the MCP server")
+@click.option("--port", type=int, default=9000, help="The port used to run the server")
+@pass_app
+def cmd(app: Application, *, port: int) -> None:
+    """
+    Start the MCP server.
+    """
+    from dda.mcp.manager import MCPManager
+
+    manager = MCPManager(app)
+    manager.start(port=port)

--- a/src/dda/cli/self/mcp_server/status/__init__.py
+++ b/src/dda/cli/self/mcp_server/status/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dda.cli.base import dynamic_command, pass_app
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+@dynamic_command(short_help="Display the MCP server status")
+@pass_app
+def cmd(app: Application) -> None:
+    """
+    Display the MCP server status.
+    """
+    from dda.mcp.manager import MCPManager
+
+    manager = MCPManager(app)
+    manager.status()

--- a/src/dda/cli/self/mcp_server/stop/__init__.py
+++ b/src/dda/cli/self/mcp_server/stop/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from dda.cli.base import dynamic_command, pass_app
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+
+
+@dynamic_command(short_help="Stop the MCP server")
+@pass_app
+def cmd(app: Application) -> None:
+    """
+    Stop the MCP server.
+    """
+    from dda.mcp.manager import MCPManager
+
+    manager = MCPManager(app)
+    manager.stop()

--- a/src/dda/mcp/__init__.py
+++ b/src/dda/mcp/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/src/dda/mcp/manager.py
+++ b/src/dda/mcp/manager.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import sys
+from functools import cached_property
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from dda.cli.application import Application
+    from dda.config.model.storage import StorageDirs
+    from dda.utils.fs import Path
+
+
+class MCPManager:
+    def __init__(self, app: Application) -> None:
+        self.__app = app
+
+    def start(self, *, port: int) -> None:
+        import json
+
+        from dda.cli.base import ensure_features_installed
+
+        ensure_features_installed(["mcp"], app=self.__app)
+
+        self.__logging_config_file.write_text(json.dumps(self.__logging_config), encoding="utf-8")
+        pid = self.__app.subprocess.spawn_daemon([
+            sys.executable,
+            "-m",
+            "pycli_mcp",
+            "dda.cli:dda",
+            "--debug",
+            "--port",
+            str(port),
+            "--log-config",
+            str(self.__logging_config_file),
+        ])
+        self.__pid_file.write_text(str(pid), encoding="utf-8")
+
+    def stop(self) -> None:
+        if not self.__pid_file.is_file():
+            self.__app.display("MCP server is not running")
+            return
+
+        import psutil
+
+        pid = int(self.__pid_file.read_text().strip())
+        try:
+            process = psutil.Process(pid)
+            process.kill()
+        except psutil.NoSuchProcess:
+            self.__app.display("MCP server is not running")
+
+        self.__pid_file.unlink()
+
+    def status(self) -> None:
+        if not self.__pid_file.is_file():
+            self.__app.display("MCP server is not running")
+            return
+
+        import psutil
+
+        pid = int(self.__pid_file.read_text().strip())
+        try:
+            process = psutil.Process(pid)
+        except psutil.NoSuchProcess:
+            self.__app.display("MCP server is not running")
+        else:
+            if process.is_running():
+                self.__app.display("MCP server is running")
+            else:
+                self.__app.display("MCP server is not running")
+
+    def show_log(self) -> None:
+        if not self.__log_file.is_file():
+            self.__app.display_warning("No logs available")
+            return
+
+        import shutil
+        import sys
+
+        with self.__log_file.open(encoding="utf-8") as f:
+            shutil.copyfileobj(f, sys.stdout)
+
+    @cached_property
+    def __pid_file(self) -> Path:
+        return self.__storage_dir.data / "server.pid"
+
+    @cached_property
+    def __log_file(self) -> Path:
+        return self.__storage_dir.cache / "server.log"
+
+    @cached_property
+    def __logging_config_file(self) -> Path:
+        return self.__storage_dir.cache / "logging.json"
+
+    @cached_property
+    def __logging_config(self) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "defaultFormatter": {
+                    "format": "%(asctime)s %(levelname)-8s %(message)s",
+                    "datefmt": "%Y-%m-%d %H:%M:%S",
+                }
+            },
+            "handlers": {
+                "fileHandler": {
+                    "class": "logging.FileHandler",
+                    "filename": str(self.__log_file),
+                    "mode": "w",
+                    "formatter": "defaultFormatter",
+                    "level": "DEBUG",
+                }
+            },
+            "root": {
+                "handlers": ["fileHandler"],
+                "level": "DEBUG",
+            },
+        }
+
+    @cached_property
+    def __storage_dir(self) -> StorageDirs:
+        dirs = self.__app.config.storage.join("mcp")
+        dirs.data.ensure_dir()
+        dirs.cache.ensure_dir()
+        return dirs

--- a/src/dda/utils/process.py
+++ b/src/dda/utils/process.py
@@ -300,7 +300,7 @@ class SubprocessRunner:
         def replace_current_process(self, command: list[str]) -> NoReturn:
             self.exit_with(command)
 
-        def spawn_daemon(self, command: list[str] | str, **kwargs: Any) -> None:
+        def spawn_daemon(self, command: list[str] | str, **kwargs: Any) -> int:
             """
             Spawn a daemon process that is detached from the current process.
 
@@ -320,14 +320,15 @@ class SubprocessRunner:
             kwargs["stderr"] = subprocess.DEVNULL
             kwargs["close_fds"] = True
             command, kwargs = self.__sanitize_arguments(command, **kwargs)
-            subprocess.Popen(command, **kwargs)
+            process = subprocess.Popen(command, **kwargs)
+            return process.pid
 
     else:
 
         def replace_current_process(self, command: list[str]) -> NoReturn:  # noqa: PLR6301
             os.execvp(command[0], command)  # noqa: S606
 
-        def spawn_daemon(self, command: list[str] | str, **kwargs: Any) -> None:
+        def spawn_daemon(self, command: list[str] | str, **kwargs: Any) -> int:
             """
             Spawn a daemon process that is detached from the current process.
 
@@ -345,7 +346,8 @@ class SubprocessRunner:
             kwargs["stderr"] = subprocess.DEVNULL
             kwargs["close_fds"] = True
             command, kwargs = self.__sanitize_arguments(command, **kwargs)
-            subprocess.Popen(command, **kwargs)
+            process = subprocess.Popen(command, **kwargs)
+            return process.pid
 
     @staticmethod
     def __sanitize_arguments(command: list[str] | str, **kwargs: Any) -> tuple[list[str] | str, dict[str, Any]]:

--- a/uv.lock
+++ b/uv.lock
@@ -518,6 +518,9 @@ legacy-test-infra-definitions = [
     { name = "pyright" },
     { name = "termcolor" },
 ]
+mcp = [
+    { name = "pycli-mcp" },
+]
 self-dev = [
     { name = "hatch" },
 ]
@@ -540,7 +543,7 @@ requires-dist = [
     { name = "psutil", specifier = "~=7.0" },
     { name = "pywinpty", marker = "sys_platform == 'win32'", specifier = "~=2.0.15" },
     { name = "rich", specifier = "~=14.0" },
-    { name = "rich-click", specifier = "~=1.8" },
+    { name = "rich-click", specifier = "~=1.8.9" },
     { name = "tomlkit", specifier = "~=0.13" },
     { name = "truststore", specifier = "~=0.10.1" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'", specifier = ">=4.6.0" },
@@ -550,8 +553,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 gcp = [
-    { name = "google-api-python-client", specifier = "==2.160.0" },
-    { name = "oauth2client", specifier = "==4.1.3" },
+    { name = "google-api-python-client", specifier = "~=2.160.0" },
+    { name = "oauth2client", specifier = "~=4.1.3" },
 ]
 github = [{ name = "pygithub" }]
 gitlab = [{ name = "python-gitlab" }]
@@ -700,6 +703,7 @@ legacy-test-infra-definitions = [
     { name = "pyright", specifier = "==1.1.391" },
     { name = "termcolor", specifier = "==2.5.0" },
 ]
+mcp = [{ name = "pycli-mcp", specifier = "~=0.3.0" }]
 self-dev = [{ name = "hatch" }]
 
 [[package]]
@@ -1055,6 +1059,15 @@ zstd = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624, upload-time = "2023-12-22T08:01:21.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819, upload-time = "2023-12-22T08:01:19.89Z" },
+]
+
+[[package]]
 name = "hvac"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1329,6 +1342,26 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
     { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/f2/dc2450e566eeccf92d89a00c3e813234ad58e2ba1e31d11467a09ac4f3b9/mcp-1.9.4.tar.gz", hash = "sha256:cfb0bcd1a9535b42edaef89947b9e18a8feb49362e1cc059d6e7fc636f2cb09f", size = 333294, upload-time = "2025-06-12T08:20:30.158Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/fc/80e655c955137393c443842ffcc4feccab5b12fa7cb8de9ced90f90e6998/mcp-1.9.4-py3-none-any.whl", hash = "sha256:7fcf36b62936adb8e63f89346bccca1268eeca9bf6dfb562ee10b1dfbda9dac0", size = 130232, upload-time = "2025-06-12T08:20:28.551Z" },
 ]
 
 [[package]]
@@ -1761,6 +1794,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pycli-mcp"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mcp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/a3/a4d36814e367d5b18e193dcd7551011d77aea19e7e2d7316483f34049ca0/pycli_mcp-0.3.0.tar.gz", hash = "sha256:974ab5ef1de7c87aced779c23da9c8f3ffec7f0e3c012178a5a38d289dbb5c44", size = 35512, upload-time = "2025-06-30T14:52:12.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/f3/ed0a043a718dfeedd45af9982eef7652a1ed38d29be9ece4ba1b08f69046/pycli_mcp-0.3.0-py3-none-any.whl", hash = "sha256:0cd5ecd99fdaf5ddf60cf27ed8777f41a53447b65c09e142a7b301dbcc71906a", size = 18550, upload-time = "2025-06-30T14:52:11.43Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1806,6 +1852,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064, upload-time = "2024-12-18T11:28:56.074Z" },
     { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046, upload-time = "2024-12-18T11:28:58.107Z" },
     { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092, upload-time = "2024-12-18T11:29:01.335Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1d/42628a2c33e93f8e9acbde0d5d735fa0850f3e6a2f8cb1eb6c40b9a732ac/pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268", size = 163234, upload-time = "2025-04-18T16:44:48.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/5f/d6d641b490fd3ec2c4c13b4244d68deea3a1b970a97be64f34fb5504ff72/pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef", size = 44356, upload-time = "2025-04-18T16:44:46.617Z" },
 ]
 
 [[package]]
@@ -1920,6 +1980,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+]
+
+[[package]]
 name = "python-gitlab"
 version = "4.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1942,6 +2011,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/31/72/58d77cb80b3c130d94f53a8204ffad9acfddb925b2fb5818ff9af0b3c832/python_levenshtein-0.26.1.tar.gz", hash = "sha256:24ba578e28058ebb4afa2700057e1678d7adf27e43cd1f17700c09a9009d5d3a", size = 12276, upload-time = "2024-10-27T22:05:15.622Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/d7/03e0453719ed89724664f781f0255949408118093dbf77a2aa2a1198b38e/python_Levenshtein-0.26.1-py3-none-any.whl", hash = "sha256:8ef5e529dd640fb00f05ee62d998d2ee862f19566b641ace775d5ae16167b2ef", size = 9426, upload-time = "2024-10-27T22:05:14.311Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
 ]
 
 [[package]]
@@ -2124,16 +2202,16 @@ wheels = [
 
 [[package]]
 name = "rich-click"
-version = "1.8.5"
+version = "1.8.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/31/103501e85e885e3e202c087fa612cfe450693210372766552ce1ab5b57b9/rich_click-1.8.5.tar.gz", hash = "sha256:a3eebe81da1c9da3c32f3810017c79bd687ff1b3fa35bfc9d8a3338797f1d1a1", size = 38229, upload-time = "2024-12-01T19:49:22.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/a8/dcc0a8ec9e91d76ecad9413a84b6d3a3310c6111cfe012d75ed385c78d96/rich_click-1.8.9.tar.gz", hash = "sha256:fd98c0ab9ddc1cf9c0b7463f68daf28b4d0033a74214ceb02f761b3ff2af3136", size = 39378, upload-time = "2025-05-19T21:33:05.569Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/0b/e2de98c538c0ee9336211d260f88b7e69affab44969750aaca0b48a697c8/rich_click-1.8.5-py3-none-any.whl", hash = "sha256:0fab7bb5b66c15da17c210b4104277cd45f3653a7322e0098820a169880baee0", size = 35081, upload-time = "2024-12-01T19:49:21.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/c2/9fce4c8a9587c4e90500114d742fe8ef0fd92d7bad29d136bb9941add271/rich_click-1.8.9-py3-none-any.whl", hash = "sha256:c3fa81ed8a671a10de65a9e20abf642cfdac6fdb882db1ef465ee33919fbcfe2", size = 36082, upload-time = "2025-05-19T21:33:04.195Z" },
 ]
 
 [[package]]
@@ -2270,6 +2348,30 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "2.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/f4/989bc70cb8091eda43a9034ef969b25145291f3601703b82766e5172dfed/sse_starlette-2.3.6.tar.gz", hash = "sha256:0382336f7d4ec30160cf9ca0518962905e1b69b72d6c1c995131e0a703b436e3", size = 18284, upload-time = "2025-05-30T13:34:12.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/05/78850ac6e79af5b9508f8841b0f26aa9fd329a1ba00bf65453c2d312bcc8/sse_starlette-2.3.6-py3-none-any.whl", hash = "sha256:d49a8285b182f6e2228e2609c350398b2ca2c36216c2675d875f81e93548f760", size = 10606, upload-time = "2025-05-30T13:34:11.703Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/d0/0332bd8a25779a0e2082b0e179805ad39afad642938b371ae0882e7f880d/starlette-0.47.0.tar.gz", hash = "sha256:1f64887e94a447fed5f23309fb6890ef23349b7e478faa7b24a851cd4eb844af", size = 2582856, upload-time = "2025-05-29T15:45:27.628Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/81/c60b35fe9674f63b38a8feafc414fca0da378a9dbd5fa1e0b8d23fcc7a9b/starlette-0.47.0-py3-none-any.whl", hash = "sha256:9d052d4933683af40ffd47c7465433570b4949dc937e20ad1d73b34e72f10c37", size = 72796, upload-time = "2025-05-29T15:45:26.305Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2398,6 +2500,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typing-inspection"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b1/0c11f5058406b3af7609f121aaa6b609744687f1d158b3c3a5bf4cc94238/typing_inspection-0.4.1.tar.gz", hash = "sha256:6ae134cc0203c33377d43188d4064e9b357dba58cff3185f22924610e70a9d28", size = 75726, upload-time = "2025-05-21T18:55:23.885Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/69/cd203477f944c353c31bade965f880aa1061fd6bf05ded0726ca845b6ff7/typing_inspection-0.4.1-py3-none-any.whl", hash = "sha256:389055682238f53b04f7badcb49b989835495a96700ced5dab2d8feae4b26f51", size = 14552, upload-time = "2025-05-21T18:55:22.152Z" },
+]
+
+[[package]]
 name = "uritemplate"
 version = "4.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2450,6 +2564,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/2e/e35b2c5669533075987e1d74da45af891890ae5faee031f90997ed81cada/uv-0.7.9-py3-none-win32.whl", hash = "sha256:298e9b3c65742edcb3097c2cf3f62ec847df174a7c62c85fe139dddaa1b9ab65", size = 17121149, upload-time = "2025-05-30T19:54:23.608Z" },
     { url = "https://files.pythonhosted.org/packages/33/8e/d10425711156d0d5d9a28299950acb3ab4a3987b3150a3c871ac95ce2fdd/uv-0.7.9-py3-none-win_amd64.whl", hash = "sha256:82d76ea988ff1347158c6de46a571b1db7d344219e452bd7b3339c21ec37cfd8", size = 18622895, upload-time = "2025-05-30T19:54:27.427Z" },
     { url = "https://files.pythonhosted.org/packages/72/77/cac29a8fb608b5613b7a0863ec6bd7c2517f3a80b94c419e9d890c12257e/uv-0.7.9-py3-none-win_arm64.whl", hash = "sha256:4d419bcc3138fd787ce77305f1a09e2a984766e0804c6e5a2b54adfa55d2439a", size = 17316542, upload-time = "2025-05-30T19:54:30.697Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.34.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ad/713be230bcda622eaa35c28f0d328c3675c371238470abdea52417f17a8e/uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a", size = 76631, upload-time = "2025-06-01T07:48:17.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/0d/8adfeaa62945f90d19ddc461c55f4a50c258af7662d34b6a3d5d1f8646f6/uvicorn-0.34.3-py3-none-any.whl", hash = "sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885", size = 62431, upload-time = "2025-06-01T07:48:15.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is the first part of 3 PRs, next will be bumping the developer image with this feature included and then automatically setting up editors when running `dda env dev code`.

This can be tested by running `dda self mcp-server start` and then saving the following config as `~/.cursor/mcp.json`:

```json
{
  "mcpServers": {
    "dda": {
      "url": "http://localhost:9000/mcp/"
    }
  }
}
```