### PR TITLE
[ABLD-77] Add `dmgbuild` Python dependency for macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ legacy-build = [
     "boto3==1.38.8",
     "codeowners==0.6.0",
     "datadog-api-client==2.34.0",
+    "dmgbuild==1.6.5; sys_platform == 'darwin'",
     "docker-squash==1.1.0",
     "docker==6.1.3",
     "dulwich==0.21.6",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.12.0, <3.13"
+requires-python = "==3.12.*"
 
 [[package]]
 name = "ada-url"
@@ -386,6 +386,7 @@ legacy-build = [
     { name = "boto3" },
     { name = "codeowners" },
     { name = "datadog-api-client" },
+    { name = "dmgbuild", marker = "sys_platform == 'darwin'" },
     { name = "docker" },
     { name = "docker-squash" },
     { name = "dulwich" },
@@ -472,6 +473,7 @@ legacy-tasks = [
     { name = "codeowners" },
     { name = "datadog-api-client" },
     { name = "debugpy" },
+    { name = "dmgbuild", marker = "sys_platform == 'darwin'" },
     { name = "docker" },
     { name = "docker-squash" },
     { name = "dulwich" },
@@ -570,6 +572,7 @@ legacy-build = [
     { name = "boto3", specifier = "==1.38.8" },
     { name = "codeowners", specifier = "==0.6.0" },
     { name = "datadog-api-client", specifier = "==2.34.0" },
+    { name = "dmgbuild", marker = "sys_platform == 'darwin'", specifier = "==1.6.5" },
     { name = "docker", specifier = "==6.1.3" },
     { name = "docker-squash", specifier = "==1.1.0" },
     { name = "dulwich", specifier = "==0.21.6" },
@@ -656,6 +659,7 @@ legacy-tasks = [
     { name = "codeowners", specifier = "==0.6.0" },
     { name = "datadog-api-client", specifier = "==2.34.0" },
     { name = "debugpy", specifier = "==1.8.2" },
+    { name = "dmgbuild", marker = "sys_platform == 'darwin'", specifier = "==1.6.5" },
     { name = "docker", specifier = "==6.1.3" },
     { name = "docker-squash", specifier = "==1.1.0" },
     { name = "dulwich", specifier = "==0.21.6" },
@@ -762,6 +766,19 @@ wheels = [
 ]
 
 [[package]]
+name = "dmgbuild"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ds-store" },
+    { name = "mac-alias" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/93/b9702c68d5dedfd6b91c76268a89091ff681b8e3b9a026e7919b6ab730a4/dmgbuild-1.6.5.tar.gz", hash = "sha256:c5cbeec574bad84a324348aa7c36d4aada04568c99fb104dec18d22ba3259f45", size = 36848, upload-time = "2025-03-21T01:04:10.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/4a/b16f1081f69592c6dba92baa4d3ca7a5685091a0f840f4b5e01be41aaf84/dmgbuild-1.6.5-py3-none-any.whl", hash = "sha256:e19ab8c5e8238e6455d9ccb9175817be7fd62b9cdd1eef20f63dd88e0ec469ab", size = 34906, upload-time = "2025-03-21T01:04:08.044Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -794,6 +811,18 @@ dependencies = [
     { name = "docker" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6c/0b/3684b7e34c46045dda03b34be50392c689b23fa8788a0c0f7daf98db35d8/docker-squash-1.1.0.tar.gz", hash = "sha256:819a87bf44c575c76d8d8f15544363a7a81ca2b176d424b67b39cd2cd9acc89e", size = 25428, upload-time = "2023-05-10T12:46:34.579Z" }
+
+[[package]]
+name = "ds-store"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mac-alias" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/36/902259bf7ddb142dd91cf7a9794aa15e1a8ab985974f90375e5d3463b441/ds_store-1.3.1.tar.gz", hash = "sha256:c27d413caf13c19acb85d75da4752673f1f38267f9eb6ba81b3b5aa99c2d207c", size = 27052, upload-time = "2022-11-24T06:13:34.376Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/bf/b1c10362a0d670ee8ae086d92c3ab795fca2a927e4ff25e7cd15224d3863/ds_store-1.3.1-py3-none-any.whl", hash = "sha256:fbacbb0bd5193ab3e66e5a47fff63619f15e374ffbec8ae29744251a6c8f05b5", size = 16268, upload-time = "2022-11-24T06:13:30.797Z" },
+]
 
 [[package]]
 name = "dulwich"
@@ -1303,6 +1332,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/fa/b361d670ffa8f477504b7fc0e5734a7878815c7e0b6769f3a5a903a94aee/lxml-5.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f11ae142f3a322d44513de1018b50f474f8f736bc3cd91d969f464b5bfef8836", size = 4972719, upload-time = "2024-05-13T05:26:20.764Z" },
     { url = "https://files.pythonhosted.org/packages/fc/43/70e469a190a8f39ca5829b4ef4f2f7299ce65243abe46ba4a73dc58c1365/lxml-5.2.2-cp312-cp312-win32.whl", hash = "sha256:16a8326e51fcdffc886294c1e70b11ddccec836516a343f9ed0f82aac043c24a", size = 3487299, upload-time = "2024-05-13T05:26:44.707Z" },
     { url = "https://files.pythonhosted.org/packages/58/16/99b03974974537c8c786fb98183d7c213ceb16e71205174a29ae869ca988/lxml-5.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:bbc4b80af581e18568ff07f6395c02114d05f4865c2812a1f02f2eaecf0bfd48", size = 3817779, upload-time = "2024-05-13T05:27:10.314Z" },
+]
+
+[[package]]
+name = "mac-alias"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/a3/83b50f620d318a98363dc7e701fb94856eaaecc472e23a89ac625697b3ea/mac_alias-2.2.2.tar.gz", hash = "sha256:c99c728eb512e955c11f1a6203a0ffa8883b26549e8afe68804031aa5da856b7", size = 34073, upload-time = "2022-12-06T00:37:47.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a1/4136777ed6a56df83e7c748ad28892f0672cbbcdc3b3d15a57df6ba72443/mac_alias-2.2.2-py3-none-any.whl", hash = "sha256:504ab8ac546f35bbd75ad014d6ad977c426660aa721f2cd3acf3dc2f664141bd", size = 21220, upload-time = "2022-12-06T00:37:46.025Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This new dependency allows to build macOS DMG images without having to tweak SIP.
See DataDog/omnibus-ruby#239 for more details. (esp. https://github.com/DataDog/omnibus-ruby/pull/239#discussion_r2179866106)

Changes in the lock file result from an execution of:
```bash
dda self dep lock
```