### PR TITLE
Safely write code editor config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Decrease the default verbosity of the telemetry daemon
 - Relax the allowed versions of Python
+- Safely write code editor configuration when parent directories do not exist
 
 ## 0.19.0 - 2025-07-03
 

--- a/src/dda/utils/editors/types/cursor.py
+++ b/src/dda/utils/editors/types/cursor.py
@@ -42,6 +42,7 @@ class CursorEditorInterface(EditorInterface):
     def __save_mcp_config(self, config: dict[str, Any]) -> None:
         import json
 
+        self.__mcp_config_file.parent.ensure_dir()
         self.__mcp_config_file.write_text(json.dumps(config, indent=4), encoding="utf-8")
 
     @cached_property

--- a/src/dda/utils/editors/types/vscode.py
+++ b/src/dda/utils/editors/types/vscode.py
@@ -42,6 +42,7 @@ class VSCodeEditorInterface(EditorInterface):
     def __save_config(self, config: dict[str, Any]) -> None:
         import json
 
+        self.__config_file.parent.ensure_dir()
         self.__config_file.write_text(json.dumps(config, indent=4), encoding="utf-8")
 
     @cached_property


### PR DESCRIPTION
Something I noticed, in practice wouldn't happen for VS Code