### PR TITLE
Fix telemetry daemon spawning on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Fix telemetry daemon spawning on Windows when installed inside a virtual environment
+
 ## 0.20.0 - 2025-07-05
 
 ***Added:***

--- a/src/dda/utils/process.py
+++ b/src/dda/utils/process.py
@@ -312,9 +312,7 @@ class SubprocessRunner:
             """
             import subprocess
 
-            kwargs["creationflags"] = (
-                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS | subprocess.CREATE_NO_WINDOW
-            )
+            kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.CREATE_NO_WINDOW
             kwargs["stdin"] = subprocess.DEVNULL
             kwargs["stdout"] = subprocess.DEVNULL
             kwargs["stderr"] = subprocess.DEVNULL


### PR DESCRIPTION
I was changing the way we configure the binaries and encountered this https://github.com/python/cpython/issues/85785