### PR TITLE
Don't use pseudo-terminals when running in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Properly set the dimensions of pseudo-terminals on Linux
 - Ensure that CLI formatting utilizes the full width of the terminal
+- Don't use pseudo-terminals when running in CI
 
 ## 0.23.1 - 2025-07-25
 

--- a/src/dda/utils/process.py
+++ b/src/dda/utils/process.py
@@ -251,7 +251,9 @@ class SubprocessRunner:
         check: bool,
         capture: bool,
     ) -> tuple[int, str]:
-        if self.__app.force_interactive:
+        from dda.utils.ci import running_in_ci
+
+        if self.__app.force_interactive or running_in_ci():
             import subprocess
 
             kwargs: dict[str, Any] = {"env": env, "cwd": cwd}

--- a/tests/utils/test_process.py
+++ b/tests/utils/test_process.py
@@ -102,6 +102,8 @@ f.write_text("foo")
         assert "Microsoft Antimalware Service" in output
 
     def test_run_reverse_interactivity(self, app, mocker, tmp_path):
+        mocker.patch("dda.utils.ci.running_in_ci", return_value=False)
+
         if app.console.is_interactive:
             from dda.utils.platform._pty.mock import PtySession
         elif sys.platform == "win32":


### PR DESCRIPTION
CI does not submit telemetry and therefore this introduces unnecessary overhead/complexity.