### PR TITLE
Add env vars for UID/GID to developer environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add `build bazel` command
 - Add `tools bazel` command group
+- Add `DD_HOST_UID` and `DD_HOST_GID` environment variables to the `linux-container` developer environment type when running on non-Windows platforms
 
 ***Fixed:***
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Add `build bazel` command
 - Add `tools bazel` command group
-- Add `DD_HOST_UID` and `DD_HOST_GID` environment variables to the `linux-container` developer environment type when running on non-Windows platforms
+- Add `HOST_UID` and `HOST_GID` environment variables to the `linux-container` developer environment type when running on non-Windows platforms
 
 ***Fixed:***
 

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
+import os
+import sys
 from functools import cached_property
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NoReturn
 
@@ -116,6 +118,16 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 f"{self.mcp_port}:9000",
                 "-v",
                 "/var/run/docker.sock:/var/run/docker.sock",
+            ]
+            if sys.platform != "win32":
+                command.extend((
+                    "-e",
+                    f"DD_HOST_UID={os.getuid()}",
+                    "-e",
+                    f"DD_HOST_GID={os.getgid()}",
+                ))
+
+            command.extend((
                 "-e",
                 "DD_SHELL",
                 "-e",
@@ -124,7 +136,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 GIT_AUTHOR_NAME_ENV_VAR,
                 "-e",
                 GIT_AUTHOR_EMAIL_ENV_VAR,
-            ]
+            ))
             if self.config.arch is not None:
                 command.extend(("--platform", f"linux/{self.config.arch}"))
 

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -122,9 +122,9 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
             if sys.platform != "win32":
                 command.extend((
                     "-e",
-                    f"DD_HOST_UID={os.getuid()}",
+                    f"HOST_UID={os.getuid()}",
                     "-e",
-                    f"DD_HOST_GID={os.getgid()}",
+                    f"HOST_GID={os.getgid()}",
                 ))
 
             command.extend((

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from subprocess import CompletedProcess
@@ -24,6 +25,11 @@ def updated_config(config_file):
     if sys.platform == "win32":
         config_file.data["env"] = {"dev": {"default-type": "linux-container"}}
         config_file.save()
+
+
+@pytest.fixture(scope="module")
+def host_user_args():
+    return [] if sys.platform == "win32" else ["-e", f"DD_HOST_UID={os.getuid()}", "-e", f"DD_HOST_GID={os.getgid()}"]
 
 
 def get_starship_mount(shared_dir: Path) -> list[str]:
@@ -141,7 +147,7 @@ class TestStart:
             """
         )
 
-    def test_default(self, dda, helpers, mocker, temp_dir):
+    def test_default(self, dda, helpers, mocker, temp_dir, host_user_args):
         repos_dir = temp_dir / "repos"
         repos_dir.ensure_dir()
         repo_dir = repos_dir / "datadog-agent"
@@ -201,6 +207,7 @@ class TestStart:
                         "50069:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
+                        *host_user_args,
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -222,7 +229,7 @@ class TestStart:
             ),
         ]
 
-    def test_clone(self, dda, helpers, mocker, temp_dir):
+    def test_clone(self, dda, helpers, mocker, temp_dir, host_user_args):
         write_server_config = mocker.patch("dda.utils.ssh.write_server_config")
         with helpers.hybrid_patch(
             "subprocess.run",
@@ -276,6 +283,7 @@ class TestStart:
                         "50069:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
+                        *host_user_args,
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -311,7 +319,7 @@ class TestStart:
             ),
         ]
 
-    def test_no_pull(self, dda, helpers, mocker, temp_dir):
+    def test_no_pull(self, dda, helpers, mocker, temp_dir, host_user_args):
         repos_dir = temp_dir / "repos"
         repos_dir.ensure_dir()
         repo_dir = repos_dir / "datadog-agent"
@@ -365,6 +373,7 @@ class TestStart:
                         "50069:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
+                        *host_user_args,
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -386,7 +395,7 @@ class TestStart:
             ),
         ]
 
-    def test_multiple(self, dda, helpers, mocker, temp_dir):
+    def test_multiple(self, dda, helpers, mocker, temp_dir, host_user_args):
         repos_dir = temp_dir / "repos"
         repos_dir.ensure_dir()
         repo1_dir = repos_dir / "datadog-agent"
@@ -448,6 +457,7 @@ class TestStart:
                         "50069:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
+                        *host_user_args,
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -471,7 +481,7 @@ class TestStart:
             ),
         ]
 
-    def test_multiple_clones(self, dda, helpers, mocker, temp_dir):
+    def test_multiple_clones(self, dda, helpers, mocker, temp_dir, host_user_args):
         write_server_config = mocker.patch("dda.utils.ssh.write_server_config")
         with helpers.hybrid_patch(
             "subprocess.run",
@@ -526,6 +536,7 @@ class TestStart:
                         "50069:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
+                        *host_user_args,
                         "-e",
                         "DD_SHELL",
                         "-e",

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -29,7 +29,7 @@ def updated_config(config_file):
 
 @pytest.fixture(scope="module")
 def host_user_args():
-    return [] if sys.platform == "win32" else ["-e", f"DD_HOST_UID={os.getuid()}", "-e", f"DD_HOST_GID={os.getgid()}"]
+    return [] if sys.platform == "win32" else ["-e", f"HOST_UID={os.getuid()}", "-e", f"HOST_GID={os.getgid()}"]
 
 
 def get_starship_mount(shared_dir: Path) -> list[str]:


### PR DESCRIPTION
In order to use artifacts built within the developer environment the permissions need to match the host. The developer environment's user is `root` and therefore when artifacts are built in a shared mount the user on the host must run `sudo` to work with the files. This prepares for a subsequent PR in the Agent repo that adds a post build step in which permissions are corrected.