### PR TITLE
Update installation docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -2,6 +2,22 @@
 
 -----
 
+## Package managers
+
+### Homebrew
+
+Install the `dda` [cask](https://formulae.brew.sh/cask/dda) using [Homebrew](https://brew.sh).
+
+```
+brew install --cask dda
+```
+
+You can upgrade to the latest version by running the following command.
+
+```
+brew upgrade --cask dda
+```
+
 ## Installers
 
 /// tab | macOS
@@ -55,6 +71,7 @@
         msiexec /passive /i https://github.com/DataDog/datadog-agent-dev/releases/latest/download/dda-x64.msi
         ```
         /////
+
         ///// tab | x86
         ```
         msiexec /passive /i https://github.com/DataDog/datadog-agent-dev/releases/latest/download/dda-x86.msi
@@ -88,15 +105,54 @@ After downloading the archive corresponding to your platform and architecture, e
 - [dda-powerpc64le-unknown-linux-gnu.tar.gz](https://github.com/DataDog/datadog-agent-dev/releases/latest/download/dda-powerpc64le-unknown-linux-gnu.tar.gz)
 ///
 
-## pip
+## Upgrade
 
-`dda` is available on PyPI and can be installed with [pip](https://github.com/pypa/pip).
+If you installed `dda` using a [package manager](#package-managers), prefer its native upgrade mechanism. Otherwise, you can upgrade to the latest version by running the following command.
 
 ```
-pip install dda
+dda self update
 ```
 
 /// warning
-- This method modifies the Python environment in which you choose to install.
-- Python 3.12.x is required.
+[Development](#development) and [manual](#manual) installations do not support this command and have their own upgrade mechanisms.
 ///
+
+## Development
+
+You can install `dda` directly from the source code, outside of release cycles. This is useful if you want to test the latest changes or contribute to the project.
+
+1. Clone the `dda` repository and enter the directory.
+
+      ```
+      git clone https://github.com/DataDog/datadog-agent-dev.git
+      cd datadog-agent-dev
+      ```
+
+2. [Install UV](https://docs.astral.sh/uv/getting-started/installation/).
+3. Run the following command to install `dda` as a [tool](https://docs.astral.sh/uv/guides/tools/#installing-tools) in development mode:
+
+      ```
+      uv tool install -e .
+      ```
+
+4. *(optional)* If installation emitted a warning about a directory not being on your `PATH`, you can add it manually or run the following command to add it automatically.
+
+      ```
+      uv tool update-shell
+      ```
+
+This will ensure that `dda` always uses the version of the code checked out in the repository. However, this will not automatically reflect changes in dependencies. To synchronize those as well at any point after installation, run the following command.
+
+```
+uv tool upgrade dda
+```
+
+## Manual
+
+/// warning
+This method is not recommended.
+///
+
+`dda` is available on [PyPI](https://pypi.org/project/dda/) and can be installed with any Python package installer like [pip](https://github.com/pypa/pip) or [UV](https://github.com/astral-sh/uv).
+
+The Python environment in which you choose to install must be at least version 3.12.


### PR DESCRIPTION
This streamlines the page by:

1. Documenting new Homebrew support: https://github.com/Homebrew/homebrew-cask/pull/222096
2. Adding explicit instructions for upgrading, and installing in development mode for contributors
3. Renaming the `pip` installation method to `Manual` with a discouraging warning