### PR TITLE
Properly build docs for releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: docs
 
 on:
   push:
+    tags:
+    - v*
     branches:
     - main
   pull_request:


### PR DESCRIPTION
This makes it so documentation is built on release tags just like the builds https://github.com/DataDog/datadog-agent-dev/blob/e7e832507e0c016e41ac734aa2bda507a410c37b/.github/workflows/build.yml#L3-L6

I noticed that the documentation had the previous version https://datadoghq.dev/datadog-agent-dev/install/

<img width="1464" height="734" alt="image" src="https://github.com/user-attachments/assets/d68299e0-0166-40c0-a2b4-4e3bca109182" />

The next commit to `main` will fix this by triggering a new docs build/push, regardless of this PR.