### PR TITLE
Don't show telemetry warnings when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Don't notify users of previous telemetry submission errors when telemetry is disabled
+
 ## 0.24.0 - 2025-08-06
 
 ***Added:***

--- a/src/dda/cli/application.py
+++ b/src/dda/cli/application.py
@@ -135,7 +135,7 @@ class Application(Terminal):
     ) -> None:
         from dda.utils.ci import running_in_ci
 
-        if self.telemetry.error_state():
+        if self.telemetry.enabled and self.telemetry.error_state():
             self.display_warning("An error occurred while submitting telemetry.")
             self.display_warning("Check the log: ", end="")
             self.display_info("dda self telemetry log show")


### PR DESCRIPTION
Such messages shouldn't be displayed if users have executed `dda self telemetry disable`.