### PR TITLE
Rename the `env dev ls` command to `env dev show`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Changed:***
+
+- Rename the `env dev ls` command to `env dev show`
+
 ## 0.24.1 - 2025-08-13
 
 ***Fixed:***

--- a/src/dda/cli/env/dev/show/__init__.py
+++ b/src/dda/cli/env/dev/show/__init__.py
@@ -11,11 +11,11 @@ if TYPE_CHECKING:
     from dda.cli.application import Application
 
 
-@dynamic_command(short_help="List the available developer environments")
+@dynamic_command(short_help="Show the available developer environments")
 @pass_app
 def cmd(app: Application) -> None:
     """
-    List the available developer environments.
+    Show the available developer environments.
     """
     import json
 


### PR DESCRIPTION
During review of https://github.com/DataDog/datadog-agent-dev/pull/159 it was noted that we should have consistent naming and `show` is better than `ls`.

The impact of this change is minimal since the command is infrequently run and developer environments have not yet been evangelized.