### PR TITLE
Persist the UV cache for developer environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ***Added:***
 
+- Persist the UV cache directory for the `linux-container` developer environment type
 - Update dependencies
 
 ## 0.24.1 - 2025-08-13

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -349,6 +349,8 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
             Mount(type="volume", path="/go/pkg/mod", source=self.get_volume_name("go_mod_cache")),
             # `pip cache dir`
             Mount(type="volume", path="/root/.cache/pip", source=self.get_volume_name("pip_cache")),
+            # `uv cache dir`
+            Mount(type="volume", path="/root/.cache/uv", source=self.get_volume_name("uv_cache")),
             # Rust
             Mount(type="volume", path="/root/.cargo/registry", source=self.get_volume_name("cargo_registry")),
             Mount(type="volume", path="/root/.cargo/git", source=self.get_volume_name("cargo_git")),

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -49,6 +49,8 @@ def get_cache_volumes() -> list[str]:
         "--mount",
         "type=volume,src=dda-env-dev-linux-container-pip_cache,dst=/root/.cache/pip",
         "--mount",
+        "type=volume,src=dda-env-dev-linux-container-uv_cache,dst=/root/.cache/uv",
+        "--mount",
         "type=volume,src=dda-env-dev-linux-container-cargo_registry,dst=/root/.cargo/registry",
         "--mount",
         "type=volume,src=dda-env-dev-linux-container-cargo_git,dst=/root/.cargo/git",


### PR DESCRIPTION
You can test the improvement by running the following before and after this change:

```
dda env dev start
dda env dev run -- dda inv -l  # time this
dda env dev stop -r
```