### PR TITLE
Use more granular test assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- The `config show` command now outputs to stdout instead of stderr
+- The error message when running an outdated version now outputs to stderr instead of stdout
+
 ## 0.28.0 - 2025-09-22
 
 ***Changed:***

--- a/src/dda/cli/__init__.py
+++ b/src/dda/cli/__init__.py
@@ -200,7 +200,7 @@ def dda(
         if current_version_parts < pinned_version_parts:
             app.display_critical(f"Repo requires at least dda version {pinned_version} but {__version__} is installed.")
             if app.managed_installation:
-                app.display("Run the following command:\ndda self update")
+                app.display_critical("Run the following command:\ndda self update")
 
             app.abort()
 

--- a/src/dda/cli/config/show/__init__.py
+++ b/src/dda/cli/config/show/__init__.py
@@ -19,4 +19,4 @@ if TYPE_CHECKING:
 def cmd(app: Application, *, all_keys: bool) -> None:
     """Render the contents of the config file."""
     text = app.config_file.read() if all_keys else app.config_file.read_scrubbed()
-    app.display_syntax(text.rstrip(), "toml")
+    app.display_syntax(text.rstrip(), "toml", stderr=False)

--- a/tests/cli/bzl/test_bzl.py
+++ b/tests/cli/bzl/test_bzl.py
@@ -18,11 +18,13 @@ def test_default_download(dda, helpers, isolation, mocker):
     with EnvVars(exclude=["PATH"]):
         result = dda("bzl", *args)
 
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        Downloading Bazelisk
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            Downloading Bazelisk
+            """
+        ),
     )
 
     internal_bazel_path = isolation.joinpath("cache", "tools", "bazel", "bazelisk").as_exe()
@@ -45,8 +47,7 @@ def test_default_exists(dda, helpers, temp_dir, mocker):
     with EnvVars({"PATH": str(temp_dir)}):
         result = dda("bzl", *args)
 
-    assert result.exit_code == 0, result.output
-    assert not result.output
+    result.check(exit_code=0)
 
     downloader.assert_not_called()
     subprocess_runner.assert_called_once_with([str(external_bazel_path), *args])
@@ -67,11 +68,13 @@ def test_config_force_managed(dda, helpers, isolation, config_file, temp_dir, mo
     with EnvVars({"PATH": str(temp_dir)}):
         result = dda("bzl", *args)
 
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        Downloading Bazelisk
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            Downloading Bazelisk
+            """
+        ),
     )
 
     internal_bazel_path = isolation.joinpath("cache", "tools", "bazel", "bazelisk").as_exe()
@@ -93,11 +96,13 @@ def test_config_force_unmanaged(dda, helpers, config_file, mocker):
     with EnvVars(exclude=["PATH"]):
         result = dda("bzl", *args)
 
-    assert result.exit_code == 1, result.output
-    assert result.output == helpers.dedent(
-        """
-        Executable `bazel` not found: ['bazel', 'build', '//...']
-        """
+    result.check(
+        exit_code=1,
+        output=helpers.dedent(
+            """
+            Executable `bazel` not found: ['bazel', 'build', '//...']
+            """
+        ),
     )
 
     downloader.assert_not_called()
@@ -114,7 +119,7 @@ def test_arg_interception(dda, config_file, mocker):
     with EnvVars(exclude=["PATH"]):
         result = dda("bzl", *args)
 
-    assert result.exit_code == 1, result.output
+    result.check_exit_code(exit_code=1)
     assert result.output.startswith("Executable `bazel` not found: ['bazel', 'build', '--target_pattern_file', '")
 
     downloader.assert_not_called()

--- a/tests/cli/config/test_explore.py
+++ b/tests/cli/config/test_explore.py
@@ -8,5 +8,5 @@ def test(dda, config_file, mocker):
     mock = mocker.patch("click.launch")
     result = dda("config", "explore")
 
-    assert result.exit_code == 0, result.output
+    result.check(exit_code=0)
     mock.assert_called_once_with(str(config_file.path), locate=True)

--- a/tests/cli/config/test_find.py
+++ b/tests/cli/config/test_find.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 def test(dda, config_file, helpers):
     result = dda("config", "find")
 
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        f"""
-        {config_file.path}
-        """
+    result.check(
+        exit_code=0,
+        stdout=helpers.dedent(
+            f"""
+            {config_file.path}
+            """
+        ),
     )

--- a/tests/cli/config/test_restore.py
+++ b/tests/cli/config/test_restore.py
@@ -4,14 +4,20 @@
 from __future__ import annotations
 
 
-def test_standard(dda, config_file):
+def test_standard(dda, config_file, helpers):
     config_file.data["terminal"]["verbosity"] = 2
     config_file.save()
 
     result = dda("config", "restore")
 
-    assert result.exit_code == 0, result.output
-    assert result.output == "Settings were successfully restored.\n"
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            Settings were successfully restored.
+            """
+        ),
+    )
 
     config_file.restore()
     assert config_file.data["terminal"]["verbosity"] == 0
@@ -23,9 +29,11 @@ def test_allow_invalid_config(dda, config_file, helpers):
 
     result = dda("config", "restore")
 
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        Settings were successfully restored.
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            Settings were successfully restored.
+            """
+        ),
     )

--- a/tests/cli/config/test_set.py
+++ b/tests/cli/config/test_set.py
@@ -8,42 +8,42 @@ import pytest
 
 def test_value_string(dda, config_file, helpers):
     result = dda("config", "set", "foo", "bar")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        foo = "bar"
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            foo = "bar"
+            """
+        ),
     )
-
     assert config_file.data["foo"] == "bar"
 
 
 def test_value_integer_positive(dda, config_file, helpers):
     result = dda("config", "set", "terminal.verbosity", "1")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        [terminal]
-        verbosity = 1
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            [terminal]
+            verbosity = 1
+            """
+        ),
     )
-
     assert config_file.model.terminal.verbosity == 1
 
 
 def test_value_integer_negative(dda, config_file, helpers):
     result = dda("config", "set", "--", "terminal.verbosity", "-1")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        [terminal]
-        verbosity = -1
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            [terminal]
+            verbosity = -1
+            """
+        ),
     )
-
     assert config_file.model.terminal.verbosity == -1
 
 
@@ -51,114 +51,124 @@ def test_value_integer_negative(dda, config_file, helpers):
 def test_value_boolean(dda, config_file, helpers, value):
     toml_value = str(value).lower()
     result = dda("config", "set", "env.dev.universal-shell", toml_value)
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        f"""
-        [env.dev]
-        universal-shell = {toml_value}
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            f"""
+            [env.dev]
+            universal-shell = {toml_value}
+            """
+        ),
     )
-
     assert config_file.model.env.dev.universal_shell is value
 
 
 def test_value_deep(dda, config_file, helpers):
     result = dda("config", "set", "github.auth.user", "foo")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        [github.auth]
-        user = "foo"
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            [github.auth]
+            user = "foo"
+            """
+        ),
     )
-
     assert config_file.model.github.auth.user == "foo"
 
 
 def test_value_complex_sequence(dda, config_file, helpers):
     result = dda("config", "set", "a.b", "['/foo', '/bar']")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        [a]
-        b = ["/foo", "/bar"]
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            [a]
+            b = ["/foo", "/bar"]
+            """
+        ),
     )
-
     assert config_file.data["a"]["b"] == ["/foo", "/bar"]
 
 
 def test_value_complex_map(dda, config_file, helpers):
     result = dda("config", "set", "z", "{'a': '/foo', 'b': '/bar'}")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        [z]
-        a = "/foo"
-        b = "/bar"
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            [z]
+            a = "/foo"
+            b = "/bar"
+            """
+        ),
     )
-
     assert config_file.data["z"] == {"a": "/foo", "b": "/bar"}
 
 
 def test_value_hidden(dda, config_file, helpers):
     result = dda("config", "set", "github.auth.token", "foo")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        [github.auth]
-        token = "*****"
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            [github.auth]
+            token = "*****"
+            """
+        ),
     )
-
     assert config_file.model.github.auth.token == "foo"
 
 
 def test_prompt(dda, config_file, helpers):
     result = dda("config", "set", "github.auth.user", input="foo")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        Value: foo
-        [github.auth]
-        user = "foo"
-        """
+    result.check(
+        exit_code=0,
+        stdout=helpers.dedent(
+            """
+            Value: foo
+            """
+        ),
+        output=helpers.dedent(
+            """
+            Value: foo
+            [github.auth]
+            user = "foo"
+            """
+        ),
     )
-
     assert config_file.model.github.auth.user == "foo"
 
 
 def test_prompt_hidden(dda, config_file, helpers):
     result = dda("config", "set", "github.auth.token", input="foo")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        f"""
-        Value:{" "}
-        [github.auth]
-        token = "*****"
-        """
+    result.check(
+        exit_code=0,
+        stdout=helpers.dedent(
+            f"""
+            Value:{" "}
+            """
+        ),
+        output=helpers.dedent(
+            f"""
+            Value:{" "}
+            [github.auth]
+            token = "*****"
+            """
+        ),
     )
-
     assert config_file.model.github.auth.token == "foo"
 
 
 def test_prevent_invalid_config(dda, config_file, helpers):
     original_verbosity = config_file.model.terminal.verbosity
     result = dda("config", "set", "terminal.verbosity", "foo")
-
-    assert result.exit_code == 1
-    assert result.output == helpers.dedent(
-        """
-        Expected `int`, got `str` - at `$.terminal.verbosity`
-        """
+    result.check(
+        exit_code=1,
+        output=helpers.dedent(
+            """
+            Expected `int`, got `str` - at `$.terminal.verbosity`
+            """
+        ),
     )
-
     assert config_file.model.terminal.verbosity == original_verbosity

--- a/tests/cli/config/test_show.py
+++ b/tests/cli/config/test_show.py
@@ -15,54 +15,56 @@ def test_default_scrubbed(dda, config_file, helpers, default_cache_dir, default_
     default_cache_directory = str(default_cache_dir).replace("\\", "\\\\")
     default_data_directory = str(default_data_dir).replace("\\", "\\\\")
 
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        f"""
-        [orgs.default]
+    result.check(
+        exit_code=0,
+        stdout=helpers.dedent(
+            f"""
+            [orgs.default]
 
-        [env.dev]
-        default-type = "{DEFAULT_DEV_ENV}"
-        clone-repos = false
-        universal-shell = false
-        editor = "vscode"
+            [env.dev]
+            default-type = "{DEFAULT_DEV_ENV}"
+            clone-repos = false
+            universal-shell = false
+            editor = "vscode"
 
-        [tools.bazel]
-        managed = "auto"
+            [tools.bazel]
+            managed = "auto"
 
-        [tools.git.author]
-        name = "{default_git_author.name}"
-        email = "{default_git_author.email}"
+            [tools.git.author]
+            name = "{default_git_author.name}"
+            email = "{default_git_author.email}"
 
-        [storage]
-        data = "{default_data_directory}"
-        cache = "{default_cache_directory}"
+            [storage]
+            data = "{default_data_directory}"
+            cache = "{default_cache_directory}"
 
-        [github.auth]
-        user = "foo"
-        token = "*****"
+            [github.auth]
+            user = "foo"
+            token = "*****"
 
-        [user]
-        name = "auto"
-        email = "auto"
+            [user]
+            name = "auto"
+            email = "auto"
 
-        [terminal]
-        verbosity = 0
+            [terminal]
+            verbosity = 0
 
-        [terminal.styles]
-        error = "bold red"
-        warning = "bold yellow"
-        info = "bold"
-        success = "bold cyan"
-        waiting = "bold magenta"
-        debug = "bold on bright_black"
-        spinner = "simpleDotsScrolling"
+            [terminal.styles]
+            error = "bold red"
+            warning = "bold yellow"
+            info = "bold"
+            success = "bold cyan"
+            waiting = "bold magenta"
+            debug = "bold on bright_black"
+            spinner = "simpleDotsScrolling"
 
-        [update]
-        mode = "check"
+            [update]
+            mode = "check"
 
-        [update.check]
-        period = "2w"
-        """
+            [update.check]
+            period = "2w"
+            """
+        ),
     )
 
 
@@ -75,52 +77,54 @@ def test_reveal(dda, config_file, helpers, default_cache_dir, default_data_dir, 
     default_cache_directory = str(default_cache_dir).replace("\\", "\\\\")
     default_data_directory = str(default_data_dir).replace("\\", "\\\\")
 
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        f"""
-        [orgs.default]
+    result.check(
+        exit_code=0,
+        stdout=helpers.dedent(
+            f"""
+            [orgs.default]
 
-        [env.dev]
-        default-type = "{DEFAULT_DEV_ENV}"
-        clone-repos = false
-        universal-shell = false
-        editor = "vscode"
+            [env.dev]
+            default-type = "{DEFAULT_DEV_ENV}"
+            clone-repos = false
+            universal-shell = false
+            editor = "vscode"
 
-        [tools.bazel]
-        managed = "auto"
+            [tools.bazel]
+            managed = "auto"
 
-        [tools.git.author]
-        name = "{default_git_author.name}"
-        email = "{default_git_author.email}"
+            [tools.git.author]
+            name = "{default_git_author.name}"
+            email = "{default_git_author.email}"
 
-        [storage]
-        data = "{default_data_directory}"
-        cache = "{default_cache_directory}"
+            [storage]
+            data = "{default_data_directory}"
+            cache = "{default_cache_directory}"
 
-        [github.auth]
-        user = "foo"
-        token = "bar"
+            [github.auth]
+            user = "foo"
+            token = "bar"
 
-        [user]
-        name = "auto"
-        email = "auto"
+            [user]
+            name = "auto"
+            email = "auto"
 
-        [terminal]
-        verbosity = 0
+            [terminal]
+            verbosity = 0
 
-        [terminal.styles]
-        error = "bold red"
-        warning = "bold yellow"
-        info = "bold"
-        success = "bold cyan"
-        waiting = "bold magenta"
-        debug = "bold on bright_black"
-        spinner = "simpleDotsScrolling"
+            [terminal.styles]
+            error = "bold red"
+            warning = "bold yellow"
+            info = "bold"
+            success = "bold cyan"
+            waiting = "bold magenta"
+            debug = "bold on bright_black"
+            spinner = "simpleDotsScrolling"
 
-        [update]
-        mode = "check"
+            [update]
+            mode = "check"
 
-        [update.check]
-        period = "2w"
-        """
+            [update.check]
+            period = "2w"
+            """
+        ),
     )

--- a/tests/cli/inv/test_inv.py
+++ b/tests/cli/inv/test_inv.py
@@ -23,13 +23,14 @@ def test_default(dda, helpers, temp_dir, uv_on_path, mocker):
     subprocess_run = mocker.patch("subprocess.run", return_value=subprocess.CompletedProcess([], returncode=0))
 
     result = dda("inv", "foo")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        Creating virtual environment
-        Synchronizing dependencies
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            Creating virtual environment
+            Synchronizing dependencies
+            """
+        ),
     )
 
     expected_path = str(uv_on_path.with_stem(f"{uv_on_path.stem}-{uv_on_path.id}"))
@@ -83,9 +84,7 @@ def test_no_dynamic_deps_flag(dda, mocker):
     )
 
     result = dda("inv", "--no-dynamic-deps", "foo")
-
-    assert result.exit_code == 0, result.output
-    assert not result.output
+    result.check(exit_code=0)
 
     assert exit_with.call_args_list == [
         mock.call(
@@ -108,8 +107,7 @@ def test_no_dynamic_deps_env_var(dda, mocker):
     with EnvVars({AppEnvVars.NO_DYNAMIC_DEPS: "1"}):
         result = dda("inv", "foo")
 
-    assert result.exit_code == 0, result.output
-    assert not result.output
+    result.check(exit_code=0)
 
     assert exit_with.call_args_list == [
         mock.call(

--- a/tests/cli/test_dynamic.py
+++ b/tests/cli/test_dynamic.py
@@ -54,19 +54,21 @@ def test_local_command(dda, helpers, temp_dir):
     with temp_dir.as_cwd():
         result = dda("config", "foo")
 
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        foo.bar='baz'
-        bar.baz='qux'
-        """
+    result.check(
+        exit_code=0,
+        stdout=helpers.dedent(
+            """
+            foo.bar='baz'
+            bar.baz='qux'
+            """
+        ),
     )
 
     with temp_dir.as_cwd():
         result = dda()
 
-    assert result.exit_code == 0, result.output
-    assert "utils" not in result.output
+    result.check_exit_code(0)
+    assert "utils" not in result.stdout
 
 
 def test_dependencies(dda, helpers, temp_dir, uv_on_path, mocker):
@@ -91,12 +93,19 @@ def test_dependencies(dda, helpers, temp_dir, uv_on_path, mocker):
     with temp_dir.as_cwd():
         result = dda("foo")
 
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        Synchronizing dependencies
-        foo
-        """
+    result.check(
+        exit_code=0,
+        stdout=helpers.dedent(
+            """
+            foo
+            """
+        ),
+        output=helpers.dedent(
+            """
+            Synchronizing dependencies
+            foo
+            """
+        ),
     )
 
     expected_path = str(uv_on_path.with_stem(f"{uv_on_path.stem}-{uv_on_path.id}"))

--- a/tests/cli/test_pin.py
+++ b/tests/cli/test_pin.py
@@ -20,16 +20,17 @@ class TestVersionMismatch:
         version_file = temp_dir / ".dda-version"
         with temp_dir.as_cwd():
             version_file.write_text(next_major_version)
-
             result = dda("config")
 
-        assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
-            f"""
-            Repo requires at least dda version {next_major_version} but {__version__} is installed.
-            Run the following command:
-            dda self update
-            """
+        result.check(
+            exit_code=1,
+            output=helpers.dedent(
+                f"""
+                Repo requires at least dda version {next_major_version} but {__version__} is installed.
+                Run the following command:
+                dda self update
+                """
+            ),
         )
 
     def test_directory(self, dda, helpers, temp_dir, next_major_version):
@@ -40,11 +41,13 @@ class TestVersionMismatch:
 
             result = dda("config")
 
-        assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
-            f"""
-            Repo requires at least dda version {next_major_version} but {__version__} is installed.
-            Run the following command:
-            dda self update
-            """
+        result.check(
+            exit_code=1,
+            output=helpers.dedent(
+                f"""
+                Repo requires at least dda version {next_major_version} but {__version__} is installed.
+                Run the following command:
+                dda self update
+                """
+            ),
         )

--- a/tests/cli/tools/test_bazel.py
+++ b/tests/cli/tools/test_bazel.py
@@ -14,12 +14,13 @@ def test_download(dda, helpers, config_file, isolation, mocker):
     downloader = mocker.patch("dda.utils.network.http.manager.HTTPClientManager.download")
 
     result = dda("tools", "bazel", "update")
-
-    assert result.exit_code == 0, result.output
-    assert result.output == helpers.dedent(
-        """
-        Downloading Bazelisk
-        """
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            Downloading Bazelisk
+            """
+        ),
     )
 
     internal_bazel_path = isolation.joinpath("cache", "tools", "bazel", "bazelisk").as_exe()
@@ -41,11 +42,13 @@ def test_unmanaged(dda, helpers, config_file, temp_dir, mocker):
     with EnvVars({"PATH": str(temp_dir)}):
         result = dda("tools", "bazel", "update")
 
-    assert result.exit_code == 1, result.output
-    assert result.output == helpers.dedent(
-        f"""
-        Bazel is not managed, using external version: {external_bazel_path}
-        """
+    result.check(
+        exit_code=1,
+        output=helpers.dedent(
+            f"""
+            Bazel is not managed, using external version: {external_bazel_path}
+            """
+        ),
     )
 
     downloader.assert_not_called()

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -96,12 +96,13 @@ class TestStatus:
     def test_default(self, dda, helpers, mocker):
         mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
         result = dda("env", "dev", "status")
-
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            State: nonexistent
-            """
+        result.check(
+            exit_code=0,
+            stdout=helpers.dedent(
+                """
+                State: nonexistent
+                """
+            ),
         )
 
     @pytest.mark.parametrize(
@@ -123,12 +124,13 @@ class TestStatus:
             return_value=CompletedProcess([], returncode=0, stdout=json.dumps([{"State": data}])),
         )
         result = dda("env", "dev", "status")
-
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            f"""
-            State: {state}
-            """
+        result.check(
+            exit_code=0,
+            stdout=helpers.dedent(
+                f"""
+                State: {state}
+                """
+            ),
         )
 
 
@@ -143,11 +145,13 @@ class TestStart:
         ):
             result = dda("env", "dev", "start")
 
-        assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
-            """
-            Cannot start developer environment `linux-container` in state `started`, must be one of: nonexistent, stopped
-            """
+        result.check(
+            exit_code=1,
+            output=helpers.dedent(
+                """
+                Cannot start developer environment `linux-container` in state `started`, must be one of: nonexistent, stopped
+                """
+            ),
         )
 
     def test_default(self, dda, helpers, mocker, temp_dir, host_user_args):
@@ -175,13 +179,15 @@ class TestStart:
         ):
             result = dda("env", "dev", "start")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Pulling image: datadog/agent-dev-env-linux
-            Creating and starting container: dda-linux-container-default
-            Waiting for container: dda-linux-container-default
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Pulling image: datadog/agent-dev-env-linux
+                Creating and starting container: dda-linux-container-default
+                Waiting for container: dda-linux-container-default
+                """
+            ),
         )
 
         assert_ssh_config_written(write_server_config, "localhost")
@@ -250,14 +256,16 @@ class TestStart:
         ) as calls:
             result = dda("env", "dev", "start", "--clone")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Pulling image: datadog/agent-dev-env-linux
-            Creating and starting container: dda-linux-container-default
-            Waiting for container: dda-linux-container-default
-            Cloning repository: datadog-agent
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Pulling image: datadog/agent-dev-env-linux
+                Creating and starting container: dda-linux-container-default
+                Waiting for container: dda-linux-container-default
+                Cloning repository: datadog-agent
+                """
+            ),
         )
 
         assert_ssh_config_written(write_server_config, "localhost")
@@ -346,12 +354,14 @@ class TestStart:
         ):
             result = dda("env", "dev", "start", "--no-pull")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Creating and starting container: dda-linux-container-default
-            Waiting for container: dda-linux-container-default
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Creating and starting container: dda-linux-container-default
+                Waiting for container: dda-linux-container-default
+                """
+            ),
         )
 
         assert_ssh_config_written(write_server_config, "localhost")
@@ -425,13 +435,15 @@ class TestStart:
         ):
             result = dda("env", "dev", "start", "-r", "datadog-agent", "-r", "integrations-core")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Pulling image: datadog/agent-dev-env-linux
-            Creating and starting container: dda-linux-container-default
-            Waiting for container: dda-linux-container-default
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Pulling image: datadog/agent-dev-env-linux
+                Creating and starting container: dda-linux-container-default
+                Waiting for container: dda-linux-container-default
+                """
+            ),
         )
 
         assert_ssh_config_written(write_server_config, "localhost")
@@ -502,15 +514,17 @@ class TestStart:
         ) as calls:
             result = dda("env", "dev", "start", "-r", "datadog-agent@tag", "-r", "integrations-core", "--clone")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Pulling image: datadog/agent-dev-env-linux
-            Creating and starting container: dda-linux-container-default
-            Waiting for container: dda-linux-container-default
-            Cloning repository: datadog-agent@tag
-            Cloning repository: integrations-core
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Pulling image: datadog/agent-dev-env-linux
+                Creating and starting container: dda-linux-container-default
+                Waiting for container: dda-linux-container-default
+                Cloning repository: datadog-agent@tag
+                Cloning repository: integrations-core
+                """
+            ),
         )
 
         assert_ssh_config_written(write_server_config, "localhost")
@@ -597,12 +611,13 @@ class TestStop:
         mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
 
         result = dda("env", "dev", "stop")
-
-        assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
-            """
-            Cannot stop developer environment `linux-container` in state `nonexistent`, must be `started`
-            """
+        result.check(
+            exit_code=1,
+            output=helpers.dedent(
+                """
+                Cannot stop developer environment `linux-container` in state `nonexistent`, must be `started`
+                """
+            ),
         )
 
     def test_default(self, dda, helpers, mocker):
@@ -616,11 +631,13 @@ class TestStop:
         ) as calls:
             result = dda("env", "dev", "stop")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Stopping container: dda-linux-container-default
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Stopping container: dda-linux-container-default
+                """
+            ),
         )
 
         assert calls == [
@@ -636,12 +653,13 @@ class TestRemove:
         mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
 
         result = dda("env", "dev", "remove")
-
-        assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
-            """
-            Cannot remove developer environment `linux-container` in state `nonexistent`, must be one of: error, stopped
-            """
+        result.check(
+            exit_code=1,
+            output=helpers.dedent(
+                """
+                Cannot remove developer environment `linux-container` in state `nonexistent`, must be one of: error, stopped
+                """
+            ),
         )
 
     def test_default(self, dda, helpers, mocker):
@@ -657,11 +675,13 @@ class TestRemove:
         ) as calls:
             result = dda("env", "dev", "remove")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Removing container: dda-linux-container-default
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Removing container: dda-linux-container-default
+                """
+            ),
         )
 
         assert calls == [
@@ -686,8 +706,7 @@ class TestShell:
 
             result = dda("env", "dev", "shell")
 
-        assert result.exit_code == 0, result.output
-        assert not result.output
+        result.check(exit_code=0)
 
         assert_ssh_config_written(write_server_config, "localhost")
         assert calls == [
@@ -715,12 +734,13 @@ class TestRun:
         mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
 
         result = dda("env", "dev", "run", "echo", "foo")
-
-        assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
-            """
-            Developer environment `linux-container` is in state `nonexistent`, must be `started`
-            """
+        result.check(
+            exit_code=1,
+            output=helpers.dedent(
+                """
+                Developer environment `linux-container` is in state `nonexistent`, must be `started`
+                """
+            ),
         )
 
     def test_default(self, dda, helpers, mocker):
@@ -736,8 +756,7 @@ class TestRun:
         ):
             result = dda("env", "dev", "run", "echo", "foo")
 
-        assert result.exit_code == 0, result.output
-        assert not result.output
+        result.check(exit_code=0)
 
         assert_ssh_config_written(write_server_config, "localhost")
         run.assert_called_once_with(
@@ -760,12 +779,13 @@ class TestCode:
         mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
 
         result = dda("env", "dev", "code")
-
-        assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
-            """
-            Developer environment `linux-container` is in state `nonexistent`, must be `started`
-            """
+        result.check(
+            exit_code=1,
+            output=helpers.dedent(
+                """
+                Developer environment `linux-container` is in state `nonexistent`, must be `started`
+                """
+            ),
         )
 
     def test_default(self, dda, helpers, mocker):
@@ -781,12 +801,14 @@ class TestCode:
         ):
             result = dda("env", "dev", "code")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Stopping MCP server
-            Starting MCP server
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Stopping MCP server
+                Starting MCP server
+                """
+            ),
         )
 
         assert_ssh_config_written(write_server_config, "localhost")
@@ -812,12 +834,14 @@ class TestCode:
         ):
             result = dda("env", "dev", "code", "--editor", "cursor")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Stopping MCP server
-            Starting MCP server
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Stopping MCP server
+                Starting MCP server
+                """
+            ),
         )
 
         assert_ssh_config_written(write_server_config, "localhost")
@@ -846,12 +870,14 @@ class TestCode:
         ):
             result = dda("env", "dev", "code")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Stopping MCP server
-            Starting MCP server
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Stopping MCP server
+                Starting MCP server
+                """
+            ),
         )
 
         assert_ssh_config_written(write_server_config, "localhost")
@@ -875,11 +901,13 @@ class TestRemoveCache:
         ):
             result = dda("env", "dev", "cache", "remove")
 
-        assert result.exit_code == 1, result.output
-        assert result.output == helpers.dedent(
-            """
-            Cannot remove cache for developer environment `linux-container` in state `started`, must be one of: nonexistent, stopped
-            """
+        result.check(
+            exit_code=1,
+            output=helpers.dedent(
+                """
+                Cannot remove cache for developer environment `linux-container` in state `started`, must be one of: nonexistent, stopped
+                """
+            ),
         )
 
     def test_default(self, dda, helpers, mocker):
@@ -895,11 +923,13 @@ class TestRemoveCache:
         ) as calls:
             result = dda("env", "dev", "cache", "remove")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Removing cache
-            """
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Removing cache
+                """
+            ),
         )
 
         assert calls == [
@@ -929,12 +959,19 @@ bar 1PB
         ):
             result = dda("env", "dev", "cache", "size")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Calculating cache size
-            1.50 GiB
-            """
+        result.check(
+            exit_code=0,
+            stdout=helpers.dedent(
+                """
+                1.50 GiB
+                """
+            ),
+            output=helpers.dedent(
+                """
+                Calculating cache size
+                1.50 GiB
+                """
+            ),
         )
 
     def test_empty(self, dda, helpers):
@@ -946,12 +983,19 @@ bar 1PB
         ):
             result = dda("env", "dev", "cache", "size")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Calculating cache size
-            Empty
-            """
+        result.check(
+            exit_code=0,
+            stdout=helpers.dedent(
+                """
+                Empty
+                """
+            ),
+            output=helpers.dedent(
+                """
+                Calculating cache size
+                Empty
+                """
+            ),
         )
 
     def test_bytes(self, dda, helpers):
@@ -972,10 +1016,17 @@ bar 1PB
         ):
             result = dda("env", "dev", "cache", "size")
 
-        assert result.exit_code == 0, result.output
-        assert result.output == helpers.dedent(
-            """
-            Calculating cache size
-            1023 B
-            """
+        result.check(
+            exit_code=0,
+            stdout=helpers.dedent(
+                """
+                1023 B
+                """
+            ),
+            output=helpers.dedent(
+                """
+                Calculating cache size
+                1023 B
+                """
+            ),
         )


### PR DESCRIPTION
This mostly changes a bunch of test assertions to use [newer](https://github.com/pallets/click/pull/2523) test properties in order to prevent issues like https://github.com/DataDog/datadog-agent-dev/pull/157. We don't want to ever accidentally include extra output.

The `dda` fixture for running commands now returns a wrapper around the Click result class. There are 2 modes of assertion behavior:

1. The `check` method asserts both the exit code (required) and output. For non-JSON output it ensures that `stdout` never has unexpected contents and enforces the correct line order of the combined stream.
2. For situations where output must be used directly there are `stdout` and `output` (combined) properties in addition to a `check_exit_code` method.