### PR TITLE
Only select stdout from subprocess captures by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - The `config show` command now outputs to stdout instead of stderr
 - The error message when running an outdated version now outputs to stderr instead of stdout
+- The `app.subprocess.capture` and `app.subprocess.redirect` methods no longer include the standard error stream by default
 
 ## 0.28.0 - 2025-09-22
 

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -202,7 +202,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
 
         from dda.env.models import EnvironmentState, EnvironmentStatus
 
-        output = self.docker.capture(["inspect", self.container_name], check=False, cross_streams=False)
+        output = self.docker.capture(["inspect", self.container_name], check=False)
         items = json.loads(output)
         if not items:
             return EnvironmentStatus(state=EnvironmentState.NONEXISTENT)

--- a/src/dda/utils/process.py
+++ b/src/dda/utils/process.py
@@ -106,7 +106,7 @@ class SubprocessRunner:
         command: list[str] | str,
         *,
         stream: BinaryIO,
-        cross_streams: bool = True,
+        cross_streams: bool = False,
         **kwargs: Any,
     ) -> subprocess.CompletedProcess:
         """
@@ -123,6 +123,7 @@ class SubprocessRunner:
         Parameters:
             command: The command to run.
             stream: The binary stream with which to redirect the command's output.
+            cross_streams: Whether to merge the command's standard error stream into its standard output stream.
 
         Returns:
             The completed process.
@@ -142,7 +143,7 @@ class SubprocessRunner:
         self,
         command: list[str],
         *,
-        cross_streams: bool = True,
+        cross_streams: bool = False,
         show: bool = False,
         check: bool = True,
         env: dict[str, str] | None = None,

--- a/tests/cli/inv/test_inv.py
+++ b/tests/cli/inv/test_inv.py
@@ -46,7 +46,7 @@ def test_default(dda, helpers, temp_dir, uv_on_path, mocker):
             ],
             encoding="utf-8",
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.PIPE,
         ),
         mock.call(
             [
@@ -60,7 +60,7 @@ def test_default(dda, helpers, temp_dir, uv_on_path, mocker):
             ],
             encoding="utf-8",
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.PIPE,
             cwd=mock.ANY,
             env=mock.ANY,
         ),

--- a/tests/cli/test_dynamic.py
+++ b/tests/cli/test_dynamic.py
@@ -121,7 +121,7 @@ def test_dependencies(dda, helpers, temp_dir, uv_on_path, mocker):
                 mocker.ANY,
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
+            stderr=subprocess.PIPE,
             encoding="utf-8",
         ),
     ]

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -198,7 +198,7 @@ class TestStart:
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
             (
                 (
@@ -234,7 +234,7 @@ class TestStart:
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
         ]
 
@@ -276,7 +276,7 @@ class TestStart:
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
             (
                 (
@@ -310,7 +310,7 @@ class TestStart:
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
             (
                 (
@@ -326,7 +326,7 @@ class TestStart:
                         "cd /root && git dd-clone datadog-agent",
                     ],
                 ),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE},
             ),
         ]
 
@@ -404,7 +404,7 @@ class TestStart:
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
         ]
 
@@ -454,7 +454,7 @@ class TestStart:
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
             (
                 (
@@ -492,7 +492,7 @@ class TestStart:
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
         ]
 
@@ -535,7 +535,7 @@ class TestStart:
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
             (
                 (
@@ -569,7 +569,7 @@ class TestStart:
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
             (
                 (
@@ -585,7 +585,7 @@ class TestStart:
                         "cd /root && git dd-clone datadog-agent tag",
                     ],
                 ),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE},
             ),
             (
                 (
@@ -601,7 +601,7 @@ class TestStart:
                         "cd /root && git dd-clone integrations-core",
                     ],
                 ),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE},
             ),
         ]
 
@@ -643,7 +643,7 @@ class TestStop:
         assert calls == [
             (
                 ([helpers.locate("docker"), "stop", "-t", "0", "dda-linux-container-default"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
         ]
 
@@ -687,7 +687,7 @@ class TestRemove:
         assert calls == [
             (
                 ([helpers.locate("docker"), "rm", "-f", "dda-linux-container-default"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
         ]
 
@@ -935,7 +935,7 @@ class TestRemoveCache:
         assert calls == [
             (
                 ([helpers.locate("docker"), "volume", "rm", "dda-env-dev-linux-container-go_build_cache"],),
-                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.STDOUT, "env": mocker.ANY},
+                {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
         ]
 


### PR DESCRIPTION
As a follow-up to https://github.com/DataDog/datadog-agent-dev/pull/195, we should match the behavior of shell redirection and only select stderr via explicit means.

#### Notes

I have an upcoming PR to fix up a Git test that hangs on my machine and when I fixed it I encountered another error due to Git config differing on CI versus my local machine. The warning from Git is captured which breaks test assertions:

```
FAILED tests/tools/git/test_git.py::test_get_changes[file_add] - assert "@@ -0,0 +1,3 @@\n+file2\n+I am a new file in the repo !\n+That's incredible.\nwarning: in the working copy of 'new_file.txt', CRLF will be replaced by LF the next time Git touches it" == "@@ -0,0 +1,3 @@\n+file2\n+I am a new file in the repo !\n+That's incredible."

    @@ -0,0 +1,3 @@
    +file2
    +I am a new file in the repo !
  - +That's incredible.
  + +That's incredible.
  ?                    +
  + warning: in the working copy of 'new_file.txt', CRLF will be replaced by LF the next time Git touches it
```

---

In future, I think we should add a way to ignore stderr completely. Right now it's still saved in memory so that failed commands can output more context but I can imagine cases where it doesn't matter and would exceed memory limits.