### PR TITLE
Update docs dependencies

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,11 +26,17 @@ jobs:
     - name: Install ourself
       run: pip install .
 
-    - name: Check documentation
-      run: dda run docs build --check
-
     - name: Build documentation
       run: dda run docs build
+
+    - name: Check links
+      uses: lycheeverse/lychee-action@885c65f3dc543b57c898c8099f4e08c8afd178a2
+      with:
+        lycheeVersion: "v0.20.1"
+        fail: true
+        failIfEmpty: true
+        # Remove `--index-files index.html` when this fix is released https://github.com/lycheeverse/lychee/pull/1843
+        args: site --index-files index.html
 
     - uses: actions/upload-artifact@v4
       with:

--- a/hatch.toml
+++ b/hatch.toml
@@ -21,18 +21,15 @@ check = "mypy --install-types --non-interactive {args:src/dda tests}"
 
 [envs.docs]
 dependencies = [
-  # https://github.com/mkdocstrings/mkdocstrings/discussions/743
-  # https://github.com/mkdocstrings/mkdocstrings/issues/756
-  "markdown @ git+https://github.com/Python-Markdown/markdown.git@e912575a903215ebafaeb0fecbdad079d998b9ba",
   "mkdocs~=1.6.1",
-  "mkdocs-material~=9.6.11",
+  "mkdocs-material~=9.6.20",
   # Plugins
   "mkdocs-minify-plugin~=0.8.0",
   # https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/issues/181
   "mkdocs-git-revision-date-localized-plugin~=1.3.0",
-  "mkdocs-glightbox~=0.4.0",
+  "mkdocs-glightbox~=0.5.1",
   "mkdocs-redirects~=1.2.2",
-  "mkdocstrings-python~=1.16.10",
+  "mkdocstrings-python~=1.18.2",
   # Extensions
   "mkdocs-click~=0.9.0",
   "pymdown-extensions~=10.14.3",
@@ -40,7 +37,7 @@ dependencies = [
   # Necessary for syntax highlighting in code blocks
   "pygments~=2.19.1",
   # Validation
-  "linkchecker~=10.5.0",
+  "linkchecker~=10.6.0",
 ]
 [envs.docs.env-vars]
 DDA_BUILDING_DOCS = "true"

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,11 @@
+require_https = true
+include_fragments = true
+index_files = ["index.html"]
+exclude = [
+  '^https://www.instagram.com/.+',
+  '^https://developer\.apple\.com/.+?#//apple_ref/doc/uid/TP0000014-TP9$',
+]
+# TODO: investigate how to account for root links e.g. `/foo`
+exclude_path = [
+  '^site(/|\\)404.html$',
+]

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -377,7 +377,8 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
         return ssh_command
 
     def check_readiness(self) -> None:
-        output = self.docker.capture(["logs", self.container_name])
+        # The `docker logs` command outputs to stderr
+        output = self.docker.capture(["logs", self.container_name], cross_streams=True)
         if "Server listening on :: port 22" not in output:
             raise RuntimeError
 


### PR DESCRIPTION
* This switches link checking of the docs site in CI to https://github.com/lycheeverse/lychee over https://github.com/linkchecker/linkchecker. It is faster and doesn't require a separate build to work around an issue (https://github.com/linkchecker/linkchecker/issues/678). The latter library is still a dependency so that local checking can occur with just a command but in future we will automatically download a binary for the former.
* Adds a comment/addendum from the previous PR.
* I tried looking into an alternative plugin to render the date on every page but it didn't work out for now https://github.com/jaywhj/mkdocs-document-dates/issues/16

---

Comparison of build + check time:

* [Before](https://github.com/DataDog/datadog-agent-dev/actions/runs/18077418652/job/51435934160): 2m 54s
* [After](https://github.com/DataDog/datadog-agent-dev/actions/runs/18085086881/job/51454816104): 14s