### PR TITLE
Finishing touches for Git utilities

### DIFF
--- a/docs/reference/api/git.md
+++ b/docs/reference/api/git.md
@@ -1,0 +1,66 @@
+# Git reference
+
+-----
+
+::: dda.tools.git.Git
+    options:
+      members:
+      - author_name
+      - author_email
+      - get_changes
+      - get_commit
+      - get_remote
+      - add
+      - commit
+      - commit_file
+
+::: dda.utils.git.commit.Commit
+    options:
+      members:
+      - sha1
+      - author
+      - committer
+      - message
+      - committer_datetime
+      - author_datetime
+
+::: dda.utils.git.commit.GitPersonDetails
+    options:
+      members:
+      - name
+      - email
+      - timestamp
+
+::: dda.utils.git.changeset.ChangeSet
+    options:
+      members:
+      - changes
+      - added
+      - modified
+      - deleted
+      - changed
+      - digest
+      - from_iter
+      - from_patches
+
+::: dda.utils.git.changeset.ChangedFile
+    options:
+      members:
+      - path
+      - type
+      - binary
+      - patch
+
+::: dda.utils.git.changeset.ChangeType
+
+::: dda.utils.git.remote.Remote
+    options:
+      members:
+      - url
+      - protocol
+      - hostname
+      - port
+      - username
+      - org
+      - repo
+      - full_repo

--- a/docs/reference/api/tools.md
+++ b/docs/reference/api/tools.md
@@ -19,10 +19,6 @@
     options:
       members: []
 
-::: dda.tools.git.Git
-    options:
-      members: []
-
 ::: dda.tools.go.Go
     options:
       members: []

--- a/lychee.toml
+++ b/lychee.toml
@@ -4,6 +4,10 @@ index_files = ["index.html"]
 exclude = [
   '^https://www.instagram.com/.+',
   '^https://developer\.apple\.com/.+?#//apple_ref/doc/uid/TP0000014-TP9$',
+  # Rendered in <head>
+  '^https://datadoghq.dev/datadog-agent-dev/.+',
+  # Edit button
+  '^https://github.com/DataDog/datadog-agent-dev/blob/main/docs/.+',
 ]
 # TODO: investigate how to account for root links e.g. `/foo`
 exclude_path = [

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - HTTP: reference/api/network/http.md
     - Retries: reference/api/retry.md
     - Platform: reference/api/platform.md
+    - Git: reference/api/git.md
     - Date: reference/api/date.md
     - Tools: reference/api/tools.md
     - CI: reference/api/ci.md

--- a/src/dda/utils/git/changeset.py
+++ b/src/dda/utils/git/changeset.py
@@ -51,15 +51,15 @@ class ChangedFile(Struct, frozen=True):
 
 
 class ChangeSet:  # noqa: PLW1641
-    def __init__(self, changes: dict[Path, ChangedFile]) -> None:
-        self.__changes = MappingProxyType(changes)
-
     """
     Represents a set of changes to files in a git repository.
     This can both be a change between two commits, or the changes in the working directory.
 
     When considering the changes to the working directory, the untracked files are considered as added files.
     """
+
+    def __init__(self, changes: dict[Path, ChangedFile]) -> None:
+        self.__changes = MappingProxyType(changes)
 
     @property
     def changes(self) -> MappingProxyType[Path, ChangedFile]:
@@ -131,10 +131,10 @@ class ChangeSet:  # noqa: PLW1641
         return cls(changes=items)
 
     @classmethod
-    def generate_from_diff_output(cls, diff_output: str | list[str]) -> Self:
+    def from_patches(cls, diff_output: str | list[str]) -> Self:
         """
         Generate a ChangeSet from the output of _some_ git diff commands.
-        Not all outputs from `git diff` are supported (ex: renames), see set of args in [Git._capture_diff_lines](dda.tools.git.Git._capture_diff_lines) method.
+        Not all outputs from `git diff` are supported (ex: renames).
         """
         import re
 

--- a/src/dda/utils/git/remote.py
+++ b/src/dda/utils/git/remote.py
@@ -3,129 +3,77 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from functools import cached_property
+from typing import TYPE_CHECKING
 
-AVAILABLE_PROTOCOLS = ("ssh", "rsync", "http", "https", "git", "file")
+if TYPE_CHECKING:
+    from ada_url import URL
 
 
-class Remote(ABC):
-    @classmethod
-    def from_url(cls, url: str) -> Remote:
-        if url.startswith(tuple(f"{protocol}://" for protocol in AVAILABLE_PROTOCOLS)):
-            return URIStyleRemote(url)
-        if "@" in url and ":" in url:
-            return RCPStyleRemote(url)
-
-        msg = f"Invalid URL: {url}"
-        raise ValueError(msg)
-
+class Remote:
     def __init__(self, url: str) -> None:
-        self.url = url
+        self.__raw_url = url
 
     @property
-    @abstractmethod
+    def url(self) -> str:
+        """
+        The URL of the remote.
+        """
+        return self.__raw_url
+
+    @cached_property
     def protocol(self) -> str:
         """
         The protocol of the remote.
         """
+        # Remove trailing colon
+        return self.__url.protocol[:-1]
 
-    @property
-    @abstractmethod
-    def authority(self) -> str:
+    @cached_property
+    def hostname(self) -> str | None:
         """
-        The authority of the remote. Includes username and port if present, under the form <username>@<host>:<port>.
+        The hostname of the remote.
         """
-
-    @property
-    @abstractmethod
-    def path(self) -> str:
-        """
-        The repository path on the remote, excluding an eventual `.git` suffix.
-        """
+        return self.__url.hostname
 
     @cached_property
     def port(self) -> int | None:
         """
-        The port of the remote. Returns None if not specified, in which case the default port for the protocol is used.
+        The port of the remote, or None if not specified.
         """
-        return int(self.authority.split(":")[1]) if ":" in self.authority else None
+        return int(self.__url.port) if self.__url.port else None
 
     @cached_property
     def username(self) -> str | None:
         """
-        The username of the remote. Returns None if not specified.
+        The username of the remote, or None if not specified.
         """
-        return self.authority.split("@")[0] if "@" in self.authority else None
-
-    @cached_property
-    def host(self) -> str | None:
-        """
-        The host of the remote.
-        """
-        prefix = self.username + "@" if self.username else ""
-        suffix = ":" + str(self.port) if self.port else ""
-        return self.authority.removeprefix(prefix).removesuffix(suffix)
-
-    def _get_org_and_repo(self) -> tuple[str, str]:
-        parts = self.path.split("/")
-        if len(parts) != 2:  # noqa: PLR2004
-            msg = f"Repo path is not under the form org/repo: {self.path}"
-            raise ValueError(msg)
-        return parts[0], parts[1]
+        return self.__url.username or None
 
     @cached_property
     def org(self) -> str:
         """
         The name of the organization the remote belongs to.
         """
-        return self._get_org_and_repo()[0]
+        return self.full_repo.split("/")[0]
 
     @cached_property
     def repo(self) -> str:
         """
         The name of the repository.
         """
-        return self._get_org_and_repo()[1]
+        return self.full_repo.split("/")[-1]
 
     @cached_property
     def full_repo(self) -> str:
-        return f"{self.org}/{self.repo}"
-
-
-# See: https://stackoverflow.com/questions/70295093/git-uris-does-not-match-ssh-uri-specification?rq=3
-class URIStyleRemote(Remote):
-    # Format: <protocol>://<some host>/<some path>(.git)
-    @cached_property
-    def protocol(self) -> str:
-        return self.url.split("://")[0]
+        return "" if self.__url.pathname == "/" else self.__url.pathname[1:].removesuffix(".git")
 
     @cached_property
-    def authority(self) -> str:
-        return self.url.split("://")[1].split("/")[0]
+    def __url(self) -> URL:
+        from ada_url import URL
 
-    @cached_property
-    def path(self) -> str:
-        return (
-            self.url.removeprefix(f"{self.protocol}://")
-            .removeprefix(self.authority)
-            .removeprefix("/")
-            .removesuffix(".git")
-        )
-
-
-class RCPStyleRemote(Remote):
-    # Format: <username>@<host>:<some path>(.git)
-    # Port cannot be specified, and the username is always present.
-    # The protocol is always SSH.
-    @cached_property
-    def protocol(self) -> str:
-        return "ssh"
-
-    @cached_property
-    def authority(self) -> str:
-        return self.url.split(":")[0]
-
-    @cached_property
-    def path(self) -> str:
-        return self.url.split(":")[1].removesuffix(".git")
+        try:
+            return URL(self.__raw_url)
+        except ValueError:
+            # SCP-style SSH
+            return URL(f"ssh://{self.__raw_url.replace(':', '/', 1)}")

--- a/tests/tools/git/conftest.py
+++ b/tests/tools/git/conftest.py
@@ -26,14 +26,14 @@ def temp_repo(app: Application, temp_dir: Path) -> Path:
     repo_path = temp_dir / "dummy-repo"
     repo_path.mkdir()  # Don't do exist_ok, the directory should not exist
     with repo_path.as_cwd():
-        app.subprocess.run(["git", "init", "--initial-branch", "main"])
+        app.subprocess.capture(["git", "init", "--initial-branch", "main"])
     return repo_path
 
 
 @pytest.fixture
 def temp_repo_with_remote(app: Application, temp_repo: Path) -> Path:
     with temp_repo.as_cwd():
-        app.tools.git.run(["remote", "add", "origin", "https://github.com/foo/bar"])
+        app.tools.git.capture(["remote", "add", "origin", "https://github.com/foo/bar"])
     return temp_repo
 
 
@@ -49,8 +49,8 @@ def _make_repo_changes(
         for file in base_dir.iterdir():
             shutil.copy(file, temp_repo / file.name)
         # -- Create commit
-        git.run(["add", "."])
-        git.run(["commit", "-m", "Initial commit"])
+        git.capture(["add", "."])
+        git.capture(["commit", "-m", "Initial commit"])
         # Create changed commit
         # -- Remove all files from temp_repo
         for file in temp_repo.iterdir():
@@ -61,8 +61,8 @@ def _make_repo_changes(
             shutil.copy(file, temp_repo / file.name)
         # -- Create commit if requested, otherwise leave working tree changes
         if commit_end:
-            git.run(["add", "."])
-            git.run(["commit", "-m", "Changed commit"])
+            git.capture(["add", "."])
+            git.capture(["commit", "-m", "Changed commit"])
 
 
 def _load_changeset(filepath: Path) -> ChangeSet:

--- a/tests/tools/git/test_git.py
+++ b/tests/tools/git/test_git.py
@@ -38,13 +38,13 @@ def assert_changesets_equal(actual: ChangeSet, expected: ChangeSet) -> None:
 
 def test_basic(app: Application, temp_repo: Path) -> None:  # type: ignore[no-untyped-def]
     with temp_repo.as_cwd():
-        assert app.tools.git.run(["status"]) == 0
+        app.tools.git.capture(["status"])
         random_key = random.randint(1, 1000000)
         with temp_repo.as_cwd():
             file = Path("testfile.txt")
             file.write_text("test")
-            app.tools.git.run(["add", str(file)])
-            app.tools.git.run(["commit", "-m", f"Initial commit: {random_key}"])
+            app.tools.git.capture(["add", str(file)])
+            app.tools.git.capture(["commit", "-m", f"Initial commit: {random_key}"])
         assert f"Initial commit: {random_key}" in app.tools.git.capture(["log", "-1", "--oneline"])
 
 
@@ -126,7 +126,7 @@ def test_get_changes(app: Application, repo_setup_working_tree: tuple[Path, Chan
         assert_changesets_equal(changeset, expected_changeset)
 
         # Case 2: Get the changes of the HEAD commit - should have the same changeset as the working tree
-        git.run(["add", "."])
+        git.add(["."])
         git.commit("New commit")
         head_sha1 = git.capture(["rev-parse", "HEAD"]).strip()
         changeset = git.get_changes()

--- a/tests/utils/git/test_changeset.py
+++ b/tests/utils/git/test_changeset.py
@@ -62,7 +62,7 @@ class TestChangeSetClass:
         "repo_testcase",
         REPO_TESTCASES,
     )
-    def test_generate_from_diff_output(self, repo_testcase):
+    def test_from_patches(self, repo_testcase):
         fixtures_dir = (
             Path(__file__).parent.parent.parent / "tools" / "git" / "fixtures" / "repo_states" / repo_testcase
         )
@@ -72,7 +72,7 @@ class TestChangeSetClass:
         with open(fixtures_dir / "expected_changeset.json", encoding="utf-8") as f:
             expected_changeset = msgspec.json.decode(f.read(), type=ChangeSet, dec_hook=dec_hook)
 
-        seen_changeset = ChangeSet.generate_from_diff_output(diff_output)
+        seen_changeset = ChangeSet.from_patches(diff_output)
 
         assert seen_changeset.keys() == expected_changeset.keys()
         for file in seen_changeset:

--- a/tests/utils/git/test_commit.py
+++ b/tests/utils/git/test_commit.py
@@ -112,9 +112,9 @@ class TestCommitClass:
             "dda.utils.network.http.client.HTTPClient.get",
             return_value=Response(status_code=200, content=github_payload_str),
         )
-        github_commit = get_commit_and_changes_from_github(
-            Remote.from_url("https://github.com/foo/bar"), reference_commit.sha1
-        )[0]
+        github_commit = get_commit_and_changes_from_github(Remote("https://github.com/foo/bar"), reference_commit.sha1)[
+            0
+        ]
 
         # Mock Git.capture to return payload from file
         git_output_file = Path(__file__).parent / "fixtures" / "git_show_dda_1425a34.txt"

--- a/tests/utils/git/test_github.py
+++ b/tests/utils/git/test_github.py
@@ -22,17 +22,17 @@ from dda.utils.git.remote import Remote
 
 
 def test_get_github_url():
-    remote = Remote.from_url(url="https://github.com/foo/bar")
+    remote = Remote("https://github.com/foo/bar")
     assert get_github_url(remote) == "https://github.com/foo/bar"
 
 
 def test_get_github_api_url():
-    remote = Remote.from_url(url="https://github.com/foo/bar")
+    remote = Remote("https://github.com/foo/bar")
     assert get_github_api_url(remote) == "https://api.github.com/repos/foo/bar"
 
 
 def test_get_commit_github_url():
-    remote = Remote.from_url(url="https://github.com/foo/bar")
+    remote = Remote("https://github.com/foo/bar")
     sha1 = "1234567890" * 4
     author = GitPersonDetails(name="a", email="a", timestamp=0)
     commit = Commit(sha1=sha1, author=author, committer=author, message="a")
@@ -40,7 +40,7 @@ def test_get_commit_github_url():
 
 
 def test_get_commit_github_api_url():
-    remote = Remote.from_url(url="https://github.com/foo/bar")
+    remote = Remote("https://github.com/foo/bar")
     sha1 = "1234567890" * 4
     author = GitPersonDetails(name="a", email="a", timestamp=0)
     commit = Commit(sha1=sha1, author=author, committer=author, message="a")
@@ -65,7 +65,7 @@ def test_get_commit_and_changes_from_github(mocker, github_payload_file):
     sha1 = data["sha"]
     commit_url = data["html_url"]
     remote_url = commit_url.split("/commit/")[0]
-    remote = Remote.from_url(url=remote_url)
+    remote = Remote(remote_url)
 
     author_timestamp = int(datetime.fromisoformat(data["commit"]["author"]["date"]).timestamp())
     author = GitPersonDetails(data["commit"]["author"]["name"], data["commit"]["author"]["email"], author_timestamp)

--- a/tests/utils/git/test_remote.py
+++ b/tests/utils/git/test_remote.py
@@ -10,38 +10,39 @@ from dda.utils.git.remote import Remote
 
 class TestRemoteClass:
     @pytest.mark.parametrize(
-        ("url", "protocol", "authority", "path", "username", "host", "port"),
+        ("url", "full_repo", "org", "repo", "protocol", "hostname", "port", "username"),
         [
             # URI Style
             # Test different protocols
-            ("https://github.com/foo/bar.git", "https", "github.com", "foo/bar", None, "github.com", None),
-            ("http://github.com/foo/bar.git", "http", "github.com", "foo/bar", None, "github.com", None),
-            ("ssh://github.com/foo/bar.git", "ssh", "github.com", "foo/bar", None, "github.com", None),
-            ("git://github.com/foo/bar.git", "git", "github.com", "foo/bar", None, "github.com", None),
-            ("file://github.com/foo/bar.git", "file", "github.com", "foo/bar", None, "github.com", None),
-            ("rsync://github.com/foo/bar.git", "rsync", "github.com", "foo/bar", None, "github.com", None),
+            ("https://github.com/foo/bar.git", "foo/bar", "foo", "bar", "https", "github.com", None, None),
+            ("http://github.com/foo/bar.git", "foo/bar", "foo", "bar", "http", "github.com", None, None),
+            ("ssh://github.com/foo/bar.git", "foo/bar", "foo", "bar", "ssh", "github.com", None, None),
+            ("git://github.com/foo/bar.git", "foo/bar", "foo", "bar", "git", "github.com", None, None),
+            ("file://github.com/foo/bar.git", "foo/bar", "foo", "bar", "file", "github.com", None, None),
+            ("rsync://github.com/foo/bar.git", "foo/bar", "foo", "bar", "rsync", "github.com", None, None),
             # Test without .git suffix
-            ("https://github.com/foo/bar", "https", "github.com", "foo/bar", None, "github.com", None),
+            ("https://github.com/foo/bar", "foo/bar", "foo", "bar", "https", "github.com", None, None),
             # Test with port and username and both
-            ("ssh://user@github.com:443/foo/bar", "ssh", "user@github.com:443", "foo/bar", "user", "github.com", 443),
-            ("ssh://user@github.com/foo/bar.git", "ssh", "user@github.com", "foo/bar", "user", "github.com", None),
-            ("rsync://github.com:2323/foo/bar.git", "rsync", "github.com:2323", "foo/bar", None, "github.com", 2323),
+            ("ssh://user@github.com:443/foo/bar", "foo/bar", "foo", "bar", "ssh", "github.com", 443, "user"),
+            ("ssh://user@github.com/foo/bar.git", "foo/bar", "foo", "bar", "ssh", "github.com", None, "user"),
+            ("rsync://github.com:2323/foo/bar.git", "foo/bar", "foo", "bar", "rsync", "github.com", 2323, None),
             # Test with a different host
-            ("https://gitlab.com/foo/bar.git", "https", "gitlab.com", "foo/bar", None, "gitlab.com", None),
-            ("ssh://user@gitlab.com:232/foo/bar", "ssh", "user@gitlab.com:232", "foo/bar", "user", "gitlab.com", 232),
-            # RCP Style
-            ("git@github.com:foo/bar.git", "ssh", "git@github.com", "foo/bar", "git", "github.com", None),
-            ("git@github.com:foo/bar", "ssh", "git@github.com", "foo/bar", "git", "github.com", None),
-            ("git@gitlab.com:foo/bar.git", "ssh", "git@gitlab.com", "foo/bar", "git", "gitlab.com", None),
-            ("git@gitlab.com:foo/bar", "ssh", "git@gitlab.com", "foo/bar", "git", "gitlab.com", None),
+            ("https://gitlab.com/foo/bar.git", "foo/bar", "foo", "bar", "https", "gitlab.com", None, None),
+            ("ssh://user@gitlab.com:232/foo/bar", "foo/bar", "foo", "bar", "ssh", "gitlab.com", 232, "user"),
+            # SCP-style SSH
+            ("git@github.com:foo/bar.git", "foo/bar", "foo", "bar", "ssh", "github.com", None, "git"),
+            ("git@github.com:foo/bar", "foo/bar", "foo", "bar", "ssh", "github.com", None, "git"),
+            ("git@gitlab.com:foo/bar.git", "foo/bar", "foo", "bar", "ssh", "gitlab.com", None, "git"),
+            ("git@gitlab.com:foo/bar", "foo/bar", "foo", "bar", "ssh", "gitlab.com", None, "git"),
         ],
     )
-    def test_basic(self, url, protocol, authority, path, username, host, port):
-        remote = Remote.from_url(url=url)
+    def test_basic(self, url, full_repo, org, repo, protocol, hostname, port, username):
+        remote = Remote(url=url)
         assert remote.url == url
+        assert remote.full_repo == full_repo
+        assert remote.org == org
+        assert remote.repo == repo
         assert remote.protocol == protocol
-        assert remote.authority == authority
-        assert remote.path == path
-        assert remote.username == username
-        assert remote.host == host
+        assert remote.hostname == hostname
         assert remote.port == port
+        assert remote.username == username


### PR DESCRIPTION
* Add utilities to the docs
* Defer to the existing `ada-url` dependency for parsing the Git remote URL
* Properly capture/hide output for the Git working tree change detection logic
* Move to the capture subprocess methods in tests for better error output and to avoid the overhead of pseudo-terminals