### PR TITLE
Instate msgspec type registration mechanism

### DIFF
--- a/src/dda/types/__init__.py
+++ b/src/dda/types/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT

--- a/src/dda/types/hooks.py
+++ b/src/dda/types/hooks.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025-present Datadog, Inc. <dev@datadoghq.com>
+#
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from msgspec import Struct
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class Hooks(Struct, frozen=True):
+    encode: Callable[[Any], Any]
+    decode: Callable[[Any], Any]
+
+
+def register_hooks(
+    typ: type[Any],
+    *,
+    encode: Callable[[Any], Any],
+    decode: Callable[[Any], Any],
+) -> None:
+    __HOOKS[typ] = Hooks(encode=encode, decode=decode)
+
+
+def enc_hook(obj: Any) -> Any:
+    if (registered_type := __HOOKS.get(type(obj))) is not None:
+        return registered_type.encode(obj)
+
+    message = f"Cannot encode: {obj!r}"
+    raise NotImplementedError(message)
+
+
+def dec_hook(typ: type[Any], obj: Any) -> Any:
+    if (registered_type := __HOOKS.get(typ)) is not None:
+        return registered_type.decode(obj)
+
+    message = f"Cannot decode: {obj!r}"
+    raise ValueError(message)
+
+
+__HOOKS: dict[type[Any], Hooks] = {}

--- a/src/dda/utils/fs.py
+++ b/src/dda/utils/fs.py
@@ -10,6 +10,8 @@ from contextlib import contextmanager
 from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any
 
+from dda.types.hooks import register_hooks
+
 if TYPE_CHECKING:
     from collections.abc import Generator
 
@@ -189,3 +191,6 @@ def temp_file(suffix: str = "") -> Generator[Path, None, None]:
 
     with NamedTemporaryFile(suffix=suffix) as f:
         yield Path(f.name).resolve()
+
+
+register_hooks(Path, encode=str, decode=Path)

--- a/tests/utils/git/test_changeset.py
+++ b/tests/utils/git/test_changeset.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import msgspec
 import pytest
 
-from dda.config.model import dec_hook, enc_hook
+from dda.types.hooks import dec_hook, enc_hook
 from dda.utils.fs import Path
 from dda.utils.git.changeset import ChangedFile, ChangeSet, ChangeType
 from tests.tools.git.conftest import REPO_TESTCASES

--- a/tests/utils/test_fs.py
+++ b/tests/utils/test_fs.py
@@ -9,7 +9,7 @@ import sys
 import msgspec
 import pytest
 
-from dda.config.model import dec_hook, enc_hook
+from dda.types.hooks import dec_hook, enc_hook
 from dda.utils.fs import Path, temp_directory
 
 


### PR DESCRIPTION
This sets up an extensible way to support encoding/decoding of custom types. At import time, modules containing custom types can register functions which the global hooks will use when that type is requested. This improves the previous way of importing all possible types within the global hooks.