### PR TITLE
Small docs update

### DIFF
--- a/docs/reference/api/fs.md
+++ b/docs/reference/api/fs.md
@@ -1,8 +1,10 @@
-# Filesystem reference
+# Filesystem utilities reference
 
 -----
 
 ::: dda.utils.fs.temp_directory
+
+::: dda.utils.fs.temp_file
 
 ::: dda.utils.fs.Path
     options:

--- a/docs/reference/api/git.md
+++ b/docs/reference/api/git.md
@@ -1,4 +1,4 @@
-# Git reference
+# Git utilities reference
 
 -----
 

--- a/docs/reference/api/platform.md
+++ b/docs/reference/api/platform.md
@@ -1,4 +1,4 @@
-# Platform reference
+# Platform utilities reference
 
 -----
 

--- a/docs/reference/api/process.md
+++ b/docs/reference/api/process.md
@@ -1,4 +1,4 @@
-# Process reference
+# Process utilities reference
 
 -----
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,9 @@ plugins:
         paths:
         - src
         options:
+          filters:
+          # Ignore both private and dunder members
+          - "!^_"
           # Rendering
           show_root_full_path: false
           # Headings

--- a/src/dda/utils/fs.py
+++ b/src/dda/utils/fs.py
@@ -161,7 +161,7 @@ def temp_directory() -> Generator[Path, None, None]:
     A context manager that creates a temporary directory and yields a path to it. Example:
 
     ```python
-    with temp_directory() as temp_dir:
+    with temp_directory() as td:
         ...
     ```
 
@@ -180,7 +180,7 @@ def temp_file(suffix: str = "") -> Generator[Path, None, None]:
     A context manager that creates a temporary file and yields a path to it. Example:
 
     ```python
-    with temp_file() as temp_file:
+    with temp_file() as tf:
         ...
     ```
 


### PR DESCRIPTION
The [default behavior](https://mkdocstrings.github.io/python/usage/configuration/members/#filters) of introspection selects special methods whereas we don't want that. Example:

<img width="343" height="400" alt="image" src="https://github.com/user-attachments/assets/b2308f0e-9336-4cf1-903a-979088f3bbfc" />

<img width="553" height="389" alt="image" src="https://github.com/user-attachments/assets/5fb7e31f-e325-4227-bfa4-e838b7724c9a" />
