### PR TITLE
starship: use `copyfile` instead of `copy` to fix `PermissionError` when copying read-only starship config

### DIFF
--- a/src/dda/env/shells/interface.py
+++ b/src/dda/env/shells/interface.py
@@ -38,7 +38,7 @@ class Shell(ABC):
             shared_files.append(shared_starship_config_file)
 
             self.shared_dir.ensure_dir()
-            shutil.copy(starship_config_file, shared_starship_config_file)
+            shutil.copyfile(starship_config_file, shared_starship_config_file)
 
         return shared_files
 


### PR DESCRIPTION
I ran into the following issue when running `dda env dev start` 

```
PermissionError: [Errno 13] Permission denied: '/Users/<user>/Library/Application Support/dda/env/dev/linux-container/.shared/shell/starship.toml'
```
Which was traced back to:

<img width="806" height="210" alt="image" src="https://github.com/user-attachments/assets/6758cc6d-9caf-414c-b926-aebbe8de648d" />  
-

It seems like when the starship config file is from a readonly source (like a nix store) the starship config file in the env dev shell inherits those read-only perms. So on the subsequent `dda env dev start` the copy ends up failing as its trying to write to a read only file. I believe `copyfile` only copies content and not permissions which should remedy this. 

It may make sense to do something more like this:
```
# force write perms 
if shared_starship_config_file.exists():                                                                                                                                                                                                    
    os.chmod(shared_starship_config_file, 0o644)                                                                                                                                                                                            
shutil.copyfile(starship_config_file, shared_starship_config_file) 
```

If this messes up anything else feel free to close this PR, it's a pretty narrow development edge case that I ran into with my setup. 