### PR TITLE
Add Datadog code coverage upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,9 +86,10 @@ jobs:
     - name: Upload coverage to Datadog
       if: steps.dd-sts.outputs.api_key != ''
       continue-on-error: true
-      run: npx @datadog/datadog-ci coverage upload coverage_data
-      env:
-        DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
+      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
+      with:
+        api_key: ${{ steps.dd-sts.outputs.api_key }}
+        files: coverage_data
 
   check:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,10 +80,9 @@ jobs:
     - name: Upload coverage to Datadog
       if: always()
       continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1
-      with:
-        api_key: ${{ secrets.DD_API_KEY }}
-        files: coverage_data
+      run: npx @datadog/datadog-ci coverage upload coverage_data
+      env:
+        DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
   check:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,10 +86,9 @@ jobs:
     - name: Upload coverage to Datadog
       if: steps.dd-sts.outputs.api_key != ''
       continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1.0.0
-      with:
-        api_key: ${{ steps.dd-sts.outputs.api_key }}
-        files: coverage_data
+      run: npx @datadog/datadog-ci@5.12.1 coverage upload coverage_data
+      env:
+        DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
 
   check:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,12 +77,18 @@ jobs:
         directory: coverage_data
         use_oidc: true
 
+    - name: Get Datadog credentials
+      id: dd-sts
+      continue-on-error: true
+      uses: DataDog/dd-sts-action@2e8187910199bd93129520183c093e19aa585c75 # v1.0.0
+      with:
+        policy: datadog-agent-dev
     - name: Upload coverage to Datadog
-      if: always()
+      if: steps.dd-sts.outputs.api_key != ''
       continue-on-error: true
       run: npx @datadog/datadog-ci coverage upload coverage_data
       env:
-        DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        DD_API_KEY: ${{ steps.dd-sts.outputs.api_key }}
 
   check:
     if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,14 @@ jobs:
         directory: coverage_data
         use_oidc: true
 
+    - name: Upload coverage to Datadog
+      if: always()
+      continue-on-error: true
+      uses: DataDog/coverage-upload-github-action@v1
+      with:
+        api_key: ${{ secrets.DD_API_KEY }}
+        files: coverage_data
+
   check:
     if: always()
     needs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Upload coverage to Datadog
       if: always()
       continue-on-error: true
-      uses: DataDog/coverage-upload-github-action@v1
+      uses: DataDog/coverage-upload-github-action@9bbbf86d16f7db1b14c5b885e61cf0d96053686a # v1
       with:
         api_key: ${{ secrets.DD_API_KEY }}
         files: coverage_data


### PR DESCRIPTION
## What does this PR do?

We're migrating Datadog repositories from Codecov to [Datadog Code Coverage](https://docs.datadoghq.com/code_analysis/code_coverage/) for tracking test coverage. This PR adds a Datadog coverage upload **alongside** the existing Codecov upload so we can run both systems in parallel and verify parity before switching over.

Replaces fork PR #249.