### PR TITLE
dda: install shared data under share/dda-data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,9 +237,9 @@ scripts = ["dda"]
 packages = ["src/dda"]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"uv.lock" = "dda-data/uv.lock"
+"uv.lock" = "share/dda-data/uv.lock"
 # TODO: remove when this is fixed https://github.com/astral-sh/uv/issues/6722
-"pyproject.toml" = "dda-data/pyproject.toml"
+"pyproject.toml" = "share/dda-data/pyproject.toml"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/dda/_version.py"

--- a/src/dda/cli/base.py
+++ b/src/dda/cli/base.py
@@ -488,7 +488,7 @@ def ensure_features_installed(
         command.extend(["--only-group", feature])
 
     with temp_directory() as temp_dir:
-        data_dir = Path(sysconfig.get_path("data")) / "dda-data"
+        data_dir = Path(sysconfig.get_path("data")) / "share" / "dda-data"
         for filename in ("uv.lock", "pyproject.toml"):
             data_file = data_dir / filename
             shutil.copy(data_file, temp_dir)


### PR DESCRIPTION
Use the proper shared-data directory for packaged DDA metadata.

Previously these files were installed directly under the Python data prefix, for example `/usr/dda-data/uv.lock` for a system-wide install or `~/.local/dda-data/uv.lock` for a user-wide install.

This change installs them under the standard shared-data location instead, for example `/usr/share/dda-data/uv.lock` and
`~/.local/share/dda-data/uv.lock`, and updates the CLI to read them from the same path at runtime.

This keeps the installed layout aligned with the usual shared-data directory convention instead of placing application data at the root of the prefix.