### PR TITLE
Support latest dev env update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Changed:***
+
+- Only support the latest version of the developer environment image for the `linux-container` developer environment type
+
 ## 0.33.3 - 2026-05-14
 
 ***Fixed:***

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -76,9 +76,9 @@ class LinuxContainerConfig(DeveloperEnvironmentConfig):
 Additional host directories to be mounted into the dev env. This option may be supplied multiple
 times, and has the same syntax as the `-v/--volume` flag of `docker run`. Examples:
 
-- `./some-repo:/root/repos/some-repo`
+- `./some-repo:/repos/some-repo`
 - `/tmp/some-location:/location:ro`
-- `~/projects:/root/projects:ro`
+- `~/projects:/projects:ro`
 """
                 ),
             }
@@ -181,7 +181,10 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
 
             for shared_shell_file in self.shell.collect_shared_files():
                 unix_path = shared_shell_file.relative_to(self.global_shared_dir).as_posix()
-                command.extend(("-v", f"{shared_shell_file}:{self.home_dir}/.shared/{unix_path}"))
+                command.extend(("-v", f"{shared_shell_file}:/.shared/{unix_path}"))
+
+            for mount in self.data_volumes:
+                command.extend(("--mount", mount.as_csv()))
 
             for mount in self.cache_volumes:
                 command.extend(("--mount", mount.as_csv()))
@@ -370,7 +373,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
 
     @cached_property
     def home_dir(self) -> str:
-        return "/root"
+        return "/home/dd"
 
     @cached_property
     def container_name(self) -> str:
@@ -383,31 +386,21 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
         return get_shell(self.config.shell)(self.global_shared_dir)
 
     @cached_property
+    def data_volumes(self) -> list[Mount]:
+        from dda.utils.container.model import Mount
+
+        return [
+            # Root data directory
+            Mount(type="volume", path="/var/lib/dd", source=self.get_volume_name("data")),
+        ]
+
+    @cached_property
     def cache_volumes(self) -> list[Mount]:
         from dda.utils.container.model import Mount
 
         return [
-            # `go env GOCACHE`
-            Mount(type="volume", path="/root/.cache/go-build", source=self.get_volume_name("go_build_cache")),
-            # `go env GOMODCACHE`
-            Mount(type="volume", path="/go/pkg/mod", source=self.get_volume_name("go_mod_cache")),
-            # `pip cache dir`
-            Mount(type="volume", path="/root/.cache/pip", source=self.get_volume_name("pip_cache")),
-            # `uv cache dir`
-            Mount(type="volume", path="/root/.cache/uv", source=self.get_volume_name("uv_cache")),
-            # Rust
-            Mount(type="volume", path="/root/.cargo/registry", source=self.get_volume_name("cargo_registry")),
-            Mount(type="volume", path="/root/.cargo/git", source=self.get_volume_name("cargo_git")),
-            # Omnibus
-            Mount(type="volume", path="/omnibus/vendor/bundle", source=self.get_volume_name("omnibus_gems")),
-            Mount(type="volume", path="/omnibus/cache", source=self.get_volume_name("omnibus_cache")),
-            Mount(
-                type="volume",
-                path="/tmp/omnibus-git-cache",  # noqa: S108
-                source=self.get_volume_name("omnibus_git_cache"),
-            ),
-            # VS Code/Cursor
-            Mount(type="volume", path="/root/.vscode-extensions", source=self.get_volume_name("vscode_extensions")),
+            # Root cache directory
+            Mount(type="volume", path="/var/cache/dd", source=self.get_volume_name("cache")),
         ]
 
     def cache_volume_names(self) -> list[str]:
@@ -437,7 +430,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
     def ssh_base_command(self) -> list[str]:
         from dda.utils.ssh import ssh_base_command
 
-        return ssh_base_command("root@localhost", self.ssh_port)
+        return ssh_base_command("dd@localhost", self.ssh_port)
 
     def ensure_ssh_config(self) -> None:
         from dda.env.ssh import ensure_ssh_config
@@ -448,7 +441,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
         if repo is None:
             repo = self.default_repo
 
-        return f"{self.home_dir}/repos/{repo}"
+        return f"/repos/{repo}"
 
     def _container_cp(self, source: str, destination: str, *args: Any) -> None:
         """Runs a `cp -r` command inside the context of the container"""

--- a/src/dda/utils/editors/types/cursor.py
+++ b/src/dda/utils/editors/types/cursor.py
@@ -12,7 +12,7 @@ from dda.utils.fs import Path
 
 class CursorEditorInterface(EditorInterface):
     def open_via_ssh(self, *, server: str, port: int, path: str) -> None:
-        self.app.subprocess.run(["cursor", "--remote", f"ssh-remote+root@{server}:{port}", path])
+        self.app.subprocess.run(["cursor", "--remote", f"ssh-remote+dd@{server}:{port}", path])
 
     def add_mcp_server(self, *, name: str, url: str) -> None:
         config = self.__load_mcp_config()
@@ -28,7 +28,7 @@ class CursorEditorInterface(EditorInterface):
 
     @staticmethod
     def __get_mcp_server_config(config: dict[str, Any]) -> dict[str, Any]:
-        # https://docs.cursor.com/context/mcp#using-mcp-json
+        # https://cursor.com/docs/mcp#using-mcpjson
         return config.setdefault("mcpServers", {})
 
     def __load_mcp_config(self) -> dict[str, Any]:
@@ -47,5 +47,5 @@ class CursorEditorInterface(EditorInterface):
 
     @cached_property
     def __mcp_config_file(self) -> Path:
-        # https://docs.cursor.com/context/mcp#configuration-locations
+        # https://cursor.com/docs/mcp#configuration-locations
         return Path.home() / ".cursor" / "mcp.json"

--- a/src/dda/utils/editors/types/vscode.py
+++ b/src/dda/utils/editors/types/vscode.py
@@ -12,7 +12,7 @@ from dda.utils.fs import Path
 
 class VSCodeEditorInterface(EditorInterface):
     def open_via_ssh(self, *, server: str, port: int, path: str) -> None:
-        self.app.subprocess.run(["code", "--remote", f"ssh-remote+root@{server}:{port}", path])
+        self.app.subprocess.run(["code", "--remote", f"ssh-remote+dd@{server}:{port}", path])
 
     def add_mcp_server(self, *, name: str, url: str) -> None:
         config = self.__load_config()
@@ -28,7 +28,7 @@ class VSCodeEditorInterface(EditorInterface):
 
     @staticmethod
     def __get_mcp_server_config(config: dict[str, Any]) -> dict[str, Any]:
-        # https://code.visualstudio.com/docs/copilot/chat/mcp-servers#_add-an-mcp-server-to-your-user-settings
+        # https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server
         return config.setdefault("mcp", {}).setdefault("servers", {})
 
     def __load_config(self) -> dict[str, Any]:

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -40,31 +40,24 @@ def get_starship_mount(global_shared_dir: Path) -> list[str]:
     if not starship_config_file.exists():
         return []
 
-    return ["-v", f"{global_shared_dir / 'shell' / 'starship.toml'}:/root/.shared/shell/starship.toml"]
+    return ["-v", f"{global_shared_dir / 'shell' / 'starship.toml'}:/.shared/shell/starship.toml"]
+
+
+def get_volumes() -> list[str]:
+    return [*get_data_volumes(), *get_cache_volumes()]
+
+
+def get_data_volumes() -> list[str]:
+    return [
+        "--mount",
+        "type=volume,src=dda-env-dev-linux-container-data,dst=/var/lib/dd",
+    ]
 
 
 def get_cache_volumes() -> list[str]:
     return [
         "--mount",
-        "type=volume,src=dda-env-dev-linux-container-go_build_cache,dst=/root/.cache/go-build",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-go_mod_cache,dst=/go/pkg/mod",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-pip_cache,dst=/root/.cache/pip",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-uv_cache,dst=/root/.cache/uv",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-cargo_registry,dst=/root/.cargo/registry",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-cargo_git,dst=/root/.cargo/git",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-omnibus_gems,dst=/omnibus/vendor/bundle",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-omnibus_cache,dst=/omnibus/cache",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-omnibus_git_cache,dst=/tmp/omnibus-git-cache",
-        "--mount",
-        "type=volume,src=dda-env-dev-linux-container-vscode_extensions,dst=/root/.vscode-extensions",
+        "type=volume,src=dda-env-dev-linux-container-cache,dst=/var/cache/dd",
     ]
 
 
@@ -199,7 +192,7 @@ class TestStart:
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / "default" / ".shared"
         global_shared_dir = shared_dir.parent.parent / ".shared"
         starship_mount = get_starship_mount(global_shared_dir)
-        cache_volumes = get_cache_volumes()
+        volumes = get_volumes()
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
@@ -236,10 +229,10 @@ class TestStart:
                         f"{shared_dir}:/.shared",
                         *starship_mount,
                         "-v",
-                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
-                        *cache_volumes,
+                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
+                        *volumes,
                         "-v",
-                        f"{repo_dir}:/root/repos/datadog-agent",
+                        f"{repo_dir}:/repos/datadog-agent",
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
@@ -282,7 +275,7 @@ class TestStart:
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / "default" / ".shared"
         global_shared_dir = shared_dir.parent.parent / ".shared"
         starship_mount = get_starship_mount(global_shared_dir)
-        cache_volumes = get_cache_volumes()
+        volumes = get_volumes()
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
@@ -319,8 +312,8 @@ class TestStart:
                         f"{shared_dir}:/.shared",
                         *starship_mount,
                         "-v",
-                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
-                        *cache_volumes,
+                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
+                        *volumes,
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
@@ -335,9 +328,9 @@ class TestStart:
                         "-t",
                         "-p",
                         "26090",
-                        "root@localhost",
+                        "dd@localhost",
                         "--",
-                        "cd /root && git dd-clone datadog-agent",
+                        "cd /home/dd && git dd-clone datadog-agent",
                     ],
                 ),
                 {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE},
@@ -383,7 +376,7 @@ class TestStart:
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / "default" / ".shared"
         global_shared_dir = shared_dir.parent.parent / ".shared"
         starship_mount = get_starship_mount(global_shared_dir)
-        cache_volumes = get_cache_volumes()
+        volumes = get_volumes()
         assert calls == [
             (
                 (
@@ -416,10 +409,10 @@ class TestStart:
                         f"{shared_dir}:/.shared",
                         *starship_mount,
                         "-v",
-                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
-                        *cache_volumes,
+                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
+                        *volumes,
                         "-v",
-                        f"{repo_dir}:/root/repos/datadog-agent",
+                        f"{repo_dir}:/repos/datadog-agent",
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
@@ -470,7 +463,7 @@ class TestStart:
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / "default" / ".shared"
         global_shared_dir = shared_dir.parent.parent / ".shared"
         starship_mount = get_starship_mount(global_shared_dir)
-        cache_volumes = get_cache_volumes()
+        volumes = get_volumes()
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
@@ -507,12 +500,12 @@ class TestStart:
                         f"{shared_dir}:/.shared",
                         *starship_mount,
                         "-v",
-                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
-                        *cache_volumes,
+                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
+                        *volumes,
                         "-v",
-                        f"{repo1_dir}:/root/repos/datadog-agent",
+                        f"{repo1_dir}:/repos/datadog-agent",
                         "-v",
-                        f"{repo2_dir}:/root/repos/integrations-core",
+                        f"{repo2_dir}:/repos/integrations-core",
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
@@ -556,7 +549,7 @@ class TestStart:
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / "default" / ".shared"
         global_shared_dir = shared_dir.parent.parent / ".shared"
         starship_mount = get_starship_mount(global_shared_dir)
-        cache_volumes = get_cache_volumes()
+        volumes = get_volumes()
         assert calls == [
             (
                 ([helpers.locate("docker"), "pull", "datadog/agent-dev-env-linux"],),
@@ -593,8 +586,8 @@ class TestStart:
                         f"{shared_dir}:/.shared",
                         *starship_mount,
                         "-v",
-                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
-                        *cache_volumes,
+                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
+                        *volumes,
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
@@ -609,9 +602,9 @@ class TestStart:
                         "-t",
                         "-p",
                         "26090",
-                        "root@localhost",
+                        "dd@localhost",
                         "--",
-                        "cd /root && git dd-clone datadog-agent tag",
+                        "cd /home/dd && git dd-clone datadog-agent tag",
                     ],
                 ),
                 {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE},
@@ -625,9 +618,9 @@ class TestStart:
                         "-t",
                         "-p",
                         "26090",
-                        "root@localhost",
+                        "dd@localhost",
                         "--",
-                        "cd /root && git dd-clone integrations-core",
+                        "cd /home/dd && git dd-clone integrations-core",
                     ],
                 ),
                 {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE},
@@ -651,7 +644,7 @@ class TestStart:
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / "default" / ".shared"
         global_shared_dir = shared_dir.parent.parent / ".shared"
         starship_mount = get_starship_mount(global_shared_dir)
-        cache_volumes = get_cache_volumes()
+        volumes = get_volumes()
 
         with (
             temp_dir.as_cwd(),
@@ -714,8 +707,8 @@ class TestStart:
                         f"{shared_dir}:/.shared",
                         *starship_mount,
                         "-v",
-                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
-                        *cache_volumes,
+                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
+                        *volumes,
                         *[(x if x != "-v" else "--volume") for x in volume_specs],
                         "datadog/agent-dev-env-linux",
                     ],
@@ -755,7 +748,7 @@ class TestStart:
         shared_dir = temp_dir / "data" / "env" / "dev" / "linux-container" / "default" / ".shared"
         global_shared_dir = shared_dir.parent.parent / ".shared"
         starship_mount = get_starship_mount(global_shared_dir)
-        cache_volumes = get_cache_volumes()
+        volumes = get_volumes()
 
         with (
             temp_dir.as_cwd(),
@@ -819,8 +812,8 @@ class TestStart:
                         f"{shared_dir}:/.shared",
                         *starship_mount,
                         "-v",
-                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/root/.shared/shell/zsh/.zsh_history",
-                        *cache_volumes,
+                        f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
+                        *volumes,
                         *[(x if x != "-m" else "--mount") for x in mount_specs],
                         "datadog/agent-dev-env-linux",
                     ],
@@ -943,9 +936,9 @@ class TestShell:
                         "-t",
                         "-p",
                         "26090",
-                        "root@localhost",
+                        "dd@localhost",
                         "--",
-                        "cd /root/repos/datadog-agent && zsh -l -i",
+                        "cd /repos/datadog-agent && zsh -l -i",
                     ],
                 ),
                 {},
@@ -991,9 +984,9 @@ class TestRun:
                 "-t",
                 "-p",
                 "26090",
-                "root@localhost",
+                "dd@localhost",
                 "--",
-                "cd /root/repos/datadog-agent && echo foo",
+                "cd /repos/datadog-agent && echo foo",
             ],
         )
 
@@ -1040,8 +1033,8 @@ class TestCode:
             [
                 "code",
                 "--remote",
-                "ssh-remote+root@localhost:26090",
-                "/root/repos/datadog-agent",
+                "ssh-remote+dd@localhost:26090",
+                "/repos/datadog-agent",
             ],
         )
 
@@ -1073,8 +1066,8 @@ class TestCode:
             [
                 "cursor",
                 "--remote",
-                "ssh-remote+root@localhost:26090",
-                "/root/repos/datadog-agent",
+                "ssh-remote+dd@localhost:26090",
+                "/repos/datadog-agent",
             ],
         )
 
@@ -1109,8 +1102,8 @@ class TestCode:
             [
                 "cursor",
                 "--remote",
-                "ssh-remote+root@localhost:26090",
-                "/root/repos/datadog-agent",
+                "ssh-remote+dd@localhost:26090",
+                "/repos/datadog-agent",
             ],
         )
 
@@ -1141,7 +1134,7 @@ class TestRemoveCache:
                 1: CompletedProcess(
                     [], returncode=0, stdout=json.dumps([{"State": {"Status": "exited", "ExitCode": 0}}])
                 ),
-                2: CompletedProcess([], returncode=0, stdout="foo\ndda-env-dev-linux-container-go_build_cache\nbar"),
+                2: CompletedProcess([], returncode=0, stdout="foo\ndda-env-dev-linux-container-cache\nbar"),
                 # Capture volume removal
             },
         ) as calls:
@@ -1158,7 +1151,7 @@ class TestRemoveCache:
 
         assert calls == [
             (
-                ([helpers.locate("docker"), "volume", "rm", "dda-env-dev-linux-container-go_build_cache"],),
+                ([helpers.locate("docker"), "volume", "rm", "dda-env-dev-linux-container-cache"],),
                 {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
         ]
@@ -1174,8 +1167,8 @@ class TestCacheSize:
                     returncode=0,
                     stdout="""\
 foo 1TB
-dda-env-dev-linux-container-go_build_cache 512MB
-dda-env-dev-linux-container-go_mod_cache 1GB
+dda-env-dev-linux-container-cache 512MB
+dda-env-dev-linux-container-data 1GB
 bar 1PB
 """,
                 ),
@@ -1187,13 +1180,13 @@ bar 1PB
             exit_code=0,
             stdout=helpers.dedent(
                 """
-                1.50 GiB
+                512.00 MiB
                 """
             ),
             output=helpers.dedent(
                 """
                 Calculating cache size
-                1.50 GiB
+                512.00 MiB
                 """
             ),
         )
@@ -1231,8 +1224,8 @@ bar 1PB
                     returncode=0,
                     stdout="""\
 foo 1TB
-dda-env-dev-linux-container-go_build_cache 1000B
-dda-env-dev-linux-container-go_mod_cache 23B
+dda-env-dev-linux-container-cache 1000B
+dda-env-dev-linux-container-data 23B
 bar 1PB
 """,
                 ),
@@ -1244,13 +1237,13 @@ bar 1PB
             exit_code=0,
             stdout=helpers.dedent(
                 """
-                1023 B
+                1000 B
                 """
             ),
             output=helpers.dedent(
                 """
                 Calculating cache size
-                1023 B
+                1000 B
                 """
             ),
         )


### PR DESCRIPTION
This makes the Linux developer environments only support versions of the image after https://github.com/DataDog/datadog-agent-buildimages/pull/1089.

### Release strategy

Rather than introduce temporary backward compatibility hacks in both the image and our tooling we will release both in lockstep.

1. Merge this
2. Create a release PR updating the `CHANGELOG.md` and merge that
3. Merge the image update
4. Wait for CI to publish the images and then cut a release here