### PR TITLE
Fix permissions of atomically-written files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ***Fixed:***
 
 - Fix the allowed range of exposed developer environment ports
+- Ensure that atomically-written files remain readable and writable by the owning group
 
 ## 0.33.1 - 2026-03-27
 

--- a/src/dda/cli/config/set/__init__.py
+++ b/src/dda/cli/config/set/__init__.py
@@ -57,7 +57,7 @@ def cmd(app: Application, key: str, value: str | None) -> None:
             new_value = default_branch
 
         new_config[key] = new_value
-        new_config = new_config[key]  # type: ignore[assignment]
+        new_config = new_config[key]
 
         key = value
         value = data.pop()

--- a/src/dda/utils/fs.py
+++ b/src/dda/utils/fs.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import os
 import pathlib
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any
 
@@ -107,15 +107,55 @@ class Path(pathlib.Path):
             *args: Additional arguments to pass to [`os.fdopen`][os.fdopen].
             **kwargs: Additional keyword arguments to pass to [`os.fdopen`][os.fdopen].
         """
-        from tempfile import mkstemp
+        from secrets import token_hex
+        from stat import S_IMODE
 
-        fd, path = mkstemp(dir=self.parent)
-        with os.fdopen(fd, *args, **kwargs) as f:
-            yield f
-            f.flush()
-            disk_sync(fd)
+        try:
+            original_permissions = S_IMODE(self.stat().st_mode)
+        except FileNotFoundError:
+            original_permissions = None
 
-        os.replace(path, self)
+        flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+        open_mode = kwargs.get("mode", args[0] if args else "")
+        if "b" in open_mode:
+            flags |= getattr(os, "O_BINARY", 0)
+
+        fd = -1
+        for _ in range(100):
+            path = self.parent / f".{self.name}.{token_hex(8)}.tmp"
+            try:
+                fd = os.open(
+                    path,
+                    flags,
+                    original_permissions if original_permissions is not None else 0o666,
+                )
+                break
+            except FileExistsError:
+                continue
+        else:
+            msg = f"Unable to create a temporary file for {self}"
+            raise FileExistsError(msg)
+
+        replaced = False
+        try:
+            with os.fdopen(fd, *args, **kwargs) as f:
+                fd = -1
+                yield f
+                f.flush()
+                disk_sync(f.fileno())
+
+            if original_permissions is not None:
+                os.chmod(path, original_permissions)
+
+            os.replace(path, self)
+            replaced = True
+        finally:
+            if fd != -1:
+                with suppress(OSError):
+                    os.close(fd)
+            if not replaced:
+                with suppress(FileNotFoundError):
+                    os.unlink(path)
 
     @contextmanager
     def as_cwd(self) -> Generator[Path, None, None]:

--- a/tests/cli/config/test_restore.py
+++ b/tests/cli/config/test_restore.py
@@ -28,7 +28,7 @@ def test_standard(dda, config_file, helpers):
 
 
 @pytest.mark.requires_unix
-def test_restore_permissions(dda, config_file):
+def test_restore_permissions(dda, config_file, helpers):
     config_file.path.unlink()
 
     old_umask = os.umask(0o002)
@@ -37,7 +37,14 @@ def test_restore_permissions(dda, config_file):
     finally:
         os.umask(old_umask)
 
-    result.check(exit_code=0)
+    result.check(
+        exit_code=0,
+        output=helpers.dedent(
+            """
+            Settings were successfully restored.
+            """
+        ),
+    )
     assert config_file.path.stat().st_mode & 0o777 == 0o664
 
 

--- a/tests/cli/config/test_restore.py
+++ b/tests/cli/config/test_restore.py
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: MIT
 from __future__ import annotations
 
+import os
+
+import pytest
+
 
 def test_standard(dda, config_file, helpers):
     config_file.data["terminal"]["verbosity"] = 2
@@ -21,6 +25,20 @@ def test_standard(dda, config_file, helpers):
 
     config_file.restore()
     assert config_file.data["terminal"]["verbosity"] == 0
+
+
+@pytest.mark.requires_unix
+def test_restore_permissions(dda, config_file):
+    config_file.path.unlink()
+
+    old_umask = os.umask(0o002)
+    try:
+        result = dda("config", "restore")
+    finally:
+        os.umask(old_umask)
+
+    result.check(exit_code=0)
+    assert config_file.path.stat().st_mode & 0o777 == 0o664
 
 
 def test_allow_invalid_config(dda, config_file, helpers):

--- a/tests/utils/test_fs.py
+++ b/tests/utils/test_fs.py
@@ -126,7 +126,7 @@ class TestPath:
 
     @pytest.mark.requires_unix
     def test_write_atomic_respects_umask_for_new_files(self, tmp_path):
-        path = Path(tmp_path, "config.toml")
+        path = Path(tmp_path, "new-config.toml")
         old_umask = os.umask(0o002)
         try:
             path.write_atomic("setting = true\n", "w", encoding="utf-8")

--- a/tests/utils/test_fs.py
+++ b/tests/utils/test_fs.py
@@ -124,6 +124,46 @@ class TestPath:
         with pytest.raises((IsADirectoryError, PermissionError)):
             non_file_path.hexdigest()
 
+    @pytest.mark.requires_unix
+    def test_write_atomic_respects_umask_for_new_files(self, tmp_path):
+        path = Path(tmp_path, "config.toml")
+        old_umask = os.umask(0o002)
+        try:
+            path.write_atomic("setting = true\n", "w", encoding="utf-8")
+        finally:
+            os.umask(old_umask)
+
+        assert path.stat().st_mode & 0o777 == 0o664
+
+    @pytest.mark.requires_unix
+    def test_write_atomic_preserves_existing_permissions(self, tmp_path):
+        path = Path(tmp_path, "config.toml")
+        path.write_text("setting = false\n", encoding="utf-8")
+        path.chmod(0o640)
+
+        old_umask = os.umask(0o077)
+        try:
+            path.write_atomic("setting = true\n", "w", encoding="utf-8")
+        finally:
+            os.umask(old_umask)
+
+        assert path.stat().st_mode & 0o777 == 0o640
+
+    @pytest.mark.requires_unix
+    def test_open_atomic_uses_existing_permissions_for_temporary_file(self, tmp_path):
+        path = Path(tmp_path, "config.toml")
+        path.write_text("setting = false\n", encoding="utf-8")
+        path.chmod(0o600)
+
+        old_umask = os.umask(0o002)
+        try:
+            with path.open_atomic("w", encoding="utf-8") as f:
+                f.write("setting = true\n")
+                (temporary_path,) = tmp_path.glob(".config.toml.*.tmp")
+                assert temporary_path.stat().st_mode & 0o777 == 0o600
+        finally:
+            os.umask(old_umask)
+
 
 def test_temp_directory():
     with temp_directory() as temp_dir:


### PR DESCRIPTION
Fix atomic config rewrites so replacement files preserve expected permissions. New config files now respect the user's umask, while rewrites preserve the existing file mode and avoid temporarily exposing private files with broader permissions.

See a workaround in the dev env [here](https://github.com/DataDog/datadog-agent-buildimages/pull/1089/changes/b3f9f81b7a5d277278188d5f822a42181252232b#diff-50e0ebc38056822e238285c13f3550b44b1f8f7197f07d97a0f805663fb57657R17). Atomic writes were creating the temporary replacement file with private owner-only permissions, so replacing `config.toml` made it inaccessible to other users in the same shared group.