### PR TITLE
Restore the `binary` dependency for the legacy Invoke task environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+***Fixed:***
+
+- Restore the `binary` dependency for the legacy Invoke task environment
+
 ## 0.34.0 - 2026-05-18
 
 ***Changed:***

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,7 +149,7 @@ plugins:
         - https://docs.python.org/3/objects.inv
         - https://click.palletsprojects.com/en/8.1.x/objects.inv
         - https://rich.readthedocs.io/en/stable/objects.inv
-        - https://jcristharif.com/msgspec/objects.inv
+        - https://msgspec.dev/objects.inv
 
 markdown_extensions:
 # Built-in

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dependencies = [
   "watchfiles~=1.1.1",
 ]
 
+# Legacy groups are installed in isolation (`--only-group`, no core dependencies),
+# so any core dependency a group needs must be repeated here.
 [dependency-groups]
 self-dev = [
     "hatch",
@@ -151,6 +153,7 @@ legacy-tasks = [
     { include-group = "legacy-notifications" },
     { include-group = "legacy-release" },
     { include-group = "legacy-test-infra-definitions" },
+    "binary==1.0.2",
     "debugpy==1.8.2",
     "rich==14.0.0",
     "watchdog==6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -667,6 +667,7 @@ legacy-release = [
 legacy-tasks = [
     { name = "atlassian-python-api" },
     { name = "beautifulsoup4" },
+    { name = "binary" },
     { name = "boto3" },
     { name = "codeowners" },
     { name = "colorama" },
@@ -872,6 +873,7 @@ legacy-release = [
 legacy-tasks = [
     { name = "atlassian-python-api", specifier = "==4.0.7" },
     { name = "beautifulsoup4", specifier = "~=4.12.3" },
+    { name = "binary", specifier = "==1.0.2" },
     { name = "boto3", specifier = "==1.38.8" },
     { name = "boto3", specifier = ">=1.28.0" },
     { name = "codeowners", specifier = "==0.6.0" },


### PR DESCRIPTION
## What does this PR do?

Re-adds `binary` to the `legacy-tasks` dependency group so it is installed into the legacy Invoke environment again.

## Motivation

5e606aa moved `binary` from `legacy-tasks`/`legacy-static-quality-gates` into `dda`'s core `dependencies`. The legacy environment is built with `uv sync --frozen --no-install-project --inexact --only-group legacy-tasks`, which installs only that group and never the core dependencies. So `binary` stopped landing in the legacy venv, breaking fresh/updated developer installs for any Invoke task importing it.

This only worked under `DDA_NO_DYNAMIC_DEPS` (CI) because there everything is installed into one shared environment.

## Verification

Built a fresh legacy venv from the updated manifest (`uv sync --frozen --no-install-project --inexact --only-group legacy-tasks` on Python 3.12) and confirmed `binary` and `invoke` both import. Also confirmed against the real v0.34.0 PyApp release binary that `--system-site-packages` could not have fixed this — `binary` lives in the dda app venv, which is invisible to the legacy venv (its base resolves to the standalone Python distribution).

## Additional Notes

This also fixes the docs build to account for the recent `msgspec` repo [transfer](https://github.com/msgspec/msgspec/pull/1045).