### PR TITLE
Fix the dev env browser proxy for Windows

### DIFF
--- a/src/dda/env/dev/browser_proxy.py
+++ b/src/dda/env/dev/browser_proxy.py
@@ -214,7 +214,7 @@ def _setup_port_forward(ssh_port: int, callback_port: int) -> None:
                 "-N",
                 "-q",
                 "-F",
-                "/dev/null",
+                "none",
                 "-o",
                 "ExitOnForwardFailure=yes",
                 "-o",

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -175,19 +175,23 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 "-v",
                 "/var/run/docker.sock:/var/run/docker.sock",
             ]
+            command.extend((
+                "--add-host",
+                "host.docker.internal:host-gateway",
+            ))
             if sys.platform != "win32":
                 command.extend((
-                    "--add-host",
-                    "host.docker.internal:host-gateway",
                     "-e",
                     f"HOST_UID={os.getuid()}",
                     "-e",
                     f"HOST_GID={os.getgid()}",
-                    "-e",
-                    "BROWSER",
-                    "-v",
-                    f"{self._xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
                 ))
+            command.extend((
+                "-e",
+                "BROWSER",
+                "-v",
+                f"{self._xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
+            ))
 
             command.extend((
                 "-e",
@@ -450,8 +454,11 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
 
     def _write_xdg_open_script(self) -> None:
         self._xdg_open_script_path.parent.ensure_dir()
+        # The script is mounted into and executed by the Linux container, so force LF line endings.
+        # Without `newline="\n"`, `write_text` on a Windows host emits CRLF and the
+        # `#!/usr/bin/env python3` shebang resolves to a nonexistent `python3\r` interpreter.
         self._xdg_open_script_path.write_text(
-            _make_xdg_open_script(self.browser_proxy_port, self.ssh_port), encoding="utf-8"
+            _make_xdg_open_script(self.browser_proxy_port, self.ssh_port), encoding="utf-8", newline="\n"
         )
         os.chmod(self._xdg_open_script_path, 0o755)  # noqa: S103
 

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -98,6 +98,18 @@ def test_default_config(app):
     }
 
 
+def test_xdg_open_script_uses_lf_line_endings(app):
+    # The script is mounted into and executed by the Linux container. CRLF endings (the
+    # Windows text-mode default) would turn the `#!/usr/bin/env python3` shebang into a
+    # nonexistent `python3\r` interpreter, so it must be written with LF on every host OS.
+    container = LinuxContainer(app=app, name="linux-container", instance="default")
+    container._write_xdg_open_script()  # noqa: SLF001
+
+    raw = container._xdg_open_script_path.read_bytes()  # noqa: SLF001
+    assert b"\r" not in raw
+    assert raw.startswith(b"#!/usr/bin/env python3\n")
+
+
 class TestStatus:
     def test_default(self, dda, helpers, mocker):
         mocker.patch("subprocess.run", return_value=CompletedProcess([], returncode=0, stdout="{}"))
@@ -224,13 +236,13 @@ class TestStart:
                         "31381:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
-                        *([] if sys.platform == "win32" else ["--add-host", "host.docker.internal:host-gateway"]),
+                        "--add-host",
+                        "host.docker.internal:host-gateway",
                         *host_user_args,
-                        *(
-                            []
-                            if sys.platform == "win32"
-                            else ["-e", "BROWSER", "-v", f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro"]
-                        ),
+                        "-e",
+                        "BROWSER",
+                        "-v",
+                        f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -314,13 +326,13 @@ class TestStart:
                         "31381:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
-                        *([] if sys.platform == "win32" else ["--add-host", "host.docker.internal:host-gateway"]),
+                        "--add-host",
+                        "host.docker.internal:host-gateway",
                         *host_user_args,
-                        *(
-                            []
-                            if sys.platform == "win32"
-                            else ["-e", "BROWSER", "-v", f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro"]
-                        ),
+                        "-e",
+                        "BROWSER",
+                        "-v",
+                        f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -418,13 +430,13 @@ class TestStart:
                         "31381:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
-                        *([] if sys.platform == "win32" else ["--add-host", "host.docker.internal:host-gateway"]),
+                        "--add-host",
+                        "host.docker.internal:host-gateway",
                         *host_user_args,
-                        *(
-                            []
-                            if sys.platform == "win32"
-                            else ["-e", "BROWSER", "-v", f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro"]
-                        ),
+                        "-e",
+                        "BROWSER",
+                        "-v",
+                        f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -516,13 +528,13 @@ class TestStart:
                         "31381:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
-                        *([] if sys.platform == "win32" else ["--add-host", "host.docker.internal:host-gateway"]),
+                        "--add-host",
+                        "host.docker.internal:host-gateway",
                         *host_user_args,
-                        *(
-                            []
-                            if sys.platform == "win32"
-                            else ["-e", "BROWSER", "-v", f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro"]
-                        ),
+                        "-e",
+                        "BROWSER",
+                        "-v",
+                        f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -609,13 +621,13 @@ class TestStart:
                         "31381:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
-                        *([] if sys.platform == "win32" else ["--add-host", "host.docker.internal:host-gateway"]),
+                        "--add-host",
+                        "host.docker.internal:host-gateway",
                         *host_user_args,
-                        *(
-                            []
-                            if sys.platform == "win32"
-                            else ["-e", "BROWSER", "-v", f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro"]
-                        ),
+                        "-e",
+                        "BROWSER",
+                        "-v",
+                        f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -737,13 +749,13 @@ class TestStart:
                         "31381:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
-                        *([] if sys.platform == "win32" else ["--add-host", "host.docker.internal:host-gateway"]),
+                        "--add-host",
+                        "host.docker.internal:host-gateway",
                         *host_user_args,
-                        *(
-                            []
-                            if sys.platform == "win32"
-                            else ["-e", "BROWSER", "-v", f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro"]
-                        ),
+                        "-e",
+                        "BROWSER",
+                        "-v",
+                        f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
                         "-e",
                         "DD_SHELL",
                         "-e",
@@ -849,13 +861,13 @@ class TestStart:
                         "31381:9000",
                         "-v",
                         "/var/run/docker.sock:/var/run/docker.sock",
-                        *([] if sys.platform == "win32" else ["--add-host", "host.docker.internal:host-gateway"]),
+                        "--add-host",
+                        "host.docker.internal:host-gateway",
                         *host_user_args,
-                        *(
-                            []
-                            if sys.platform == "win32"
-                            else ["-e", "BROWSER", "-v", f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro"]
-                        ),
+                        "-e",
+                        "BROWSER",
+                        "-v",
+                        f"{xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
                         "-e",
                         "DD_SHELL",
                         "-e",


### PR DESCRIPTION
Most of this was working on Windows except for referencing `/dev/null` and mounting a shell script with Windows line endings.