### PR TITLE
Share host AWS config with the Linux dev env

### DIFF
--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -18,10 +18,9 @@ from dda.utils.git.constants import GitEnvVars
 def _make_xdg_open_script(proxy_port: int, ssh_port: int) -> str:
     """Return the xdg-open script with both ports substituted.
 
-    Both the shared proxy port and the container's own SSH port are baked in
-    so the script works in SSH sessions (which do not inherit Docker ``-e``
-    variables) and so the single shared daemon knows which container to tunnel
-    back to for OAuth callbacks.
+    The ports are substituted into the script rather than read from the environment so it stays
+    self-contained for the tools that invoke it, and so the single shared daemon knows which
+    container to tunnel back to for OAuth callbacks.
     """
     import importlib.resources
 
@@ -202,6 +201,8 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 f"{self._xdg_open_script_path}:/usr/local/bin/xdg-open:ro",
             ))
 
+            # These forwarded env vars reach SSH `run`/`shell` sessions, not just the daemon, because
+            # the image persists them to /etc/environment and pam_env loads them per session.
             command.extend((
                 "-e",
                 "DD_SHELL",

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -83,6 +83,15 @@ class LinuxContainerConfig(DeveloperEnvironmentConfig):
             }
         ),
     ] = None
+    no_secrets: Annotated[
+        bool,
+        msgspec.Meta(
+            extra={
+                "params": ["--no-secrets"],
+                "help": "Do not share host credentials or secrets (currently the `~/.aws` directory) with the dev env",
+            }
+        ),
+    ] = False
     # This parameter stores the raw volume specifications as provided by the user.
     # Use the `extra_mounts` property to get the list of extra mounts as Mount objects.
     extra_volume_specs: Annotated[
@@ -223,6 +232,24 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
 
             for mount in self.cache_volumes:
                 command.extend(("--mount", mount.as_csv()))
+
+            if not self.config.no_secrets:
+                from dda.utils.container.model import Mount
+                from dda.utils.fs import Path
+
+                aws_dir = Path.home() / ".aws"
+                if aws_dir.is_dir():
+                    # Mount ~/.aws read-write so the container can refresh its SSO token cache.
+                    command.extend((
+                        "--mount",
+                        Mount(type="bind", source=str(aws_dir), path=f"{self.home_dir}/.aws").as_csv(),
+                        "-e",
+                        "AWS_PROFILE",
+                        "-e",
+                        "AWS_REGION",
+                        "-e",
+                        "AWS_DEFAULT_REGION",
+                    ))
 
             if not self.config.clone:
                 from dda.utils.fs import Path

--- a/src/dda/env/dev/types/linux_container.py
+++ b/src/dda/env/dev/types/linux_container.py
@@ -87,7 +87,7 @@ class LinuxContainerConfig(DeveloperEnvironmentConfig):
         msgspec.Meta(
             extra={
                 "params": ["--no-secrets"],
-                "help": "Do not share host credentials or secrets (currently the `~/.aws` directory) with the dev env",
+                "help": "Do not share host credentials or secrets with the dev env",
             }
         ),
     ] = False
@@ -218,7 +218,14 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 AppEnvVars.ENV_TYPE,
                 "-e",
                 AppEnvVars.ENV_MANAGER,
+                "-e",
+                "AWS_PROFILE",
+                "-e",
+                "AWS_REGION",
+                "-e",
+                "AWS_DEFAULT_REGION",
             ))
+
             if self.config.arch is not None:
                 command.extend(("--platform", f"linux/{self.config.arch}"))
 
@@ -235,22 +242,7 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
                 command.extend(("--mount", mount.as_csv()))
 
             if not self.config.no_secrets:
-                from dda.utils.container.model import Mount
-                from dda.utils.fs import Path
-
-                aws_dir = Path.home() / ".aws"
-                if aws_dir.is_dir():
-                    # Mount ~/.aws read-write so the container can refresh its SSO token cache.
-                    command.extend((
-                        "--mount",
-                        Mount(type="bind", source=str(aws_dir), path=f"{self.home_dir}/.aws").as_csv(),
-                        "-e",
-                        "AWS_PROFILE",
-                        "-e",
-                        "AWS_REGION",
-                        "-e",
-                        "AWS_DEFAULT_REGION",
-                    ))
+                self._add_secret_mounts(command)
 
             if not self.config.clone:
                 from dda.utils.fs import Path
@@ -485,6 +477,18 @@ class LinuxContainer(DeveloperEnvironmentInterface[LinuxContainerConfig]):
         if self.config.arch is not None:
             name += f"-{self.config.arch}"
         return name
+
+    def _add_secret_mounts(self, command: list[str]) -> None:
+        from dda.utils.container.model import Mount
+        from dda.utils.fs import Path
+
+        # Share ~/.aws read-write so the container can refresh its SSO token cache.
+        aws_dir = Path.home() / ".aws"
+        if aws_dir.is_dir():
+            command.extend((
+                "--mount",
+                Mount(type="bind", source=str(aws_dir), path=f"{self.home_dir}/.aws").as_csv(),
+            ))
 
     def _write_xdg_open_script(self) -> None:
         self._xdg_open_script_path.parent.ensure_dir()

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -62,12 +62,6 @@ def get_aws_mount(home_dir: str = "/home/dd") -> list[str]:
     return [
         "--mount",
         Mount(type="bind", source=str(aws_dir), path=f"{home_dir}/.aws").as_csv(),
-        "-e",
-        "AWS_PROFILE",
-        "-e",
-        "AWS_REGION",
-        "-e",
-        "AWS_DEFAULT_REGION",
     ]
 
 
@@ -277,6 +271,12 @@ class TestStart:
                         AppEnvVars.ENV_TYPE,
                         "-e",
                         AppEnvVars.ENV_MANAGER,
+                        "-e",
+                        "AWS_PROFILE",
+                        "-e",
+                        "AWS_REGION",
+                        "-e",
+                        "AWS_DEFAULT_REGION",
                         "-v",
                         f"{shared_dir}:/.shared",
                         *starship_mount,
@@ -372,6 +372,12 @@ class TestStart:
                         AppEnvVars.ENV_TYPE,
                         "-e",
                         AppEnvVars.ENV_MANAGER,
+                        "-e",
+                        "AWS_PROFILE",
+                        "-e",
+                        "AWS_REGION",
+                        "-e",
+                        "AWS_DEFAULT_REGION",
                         "-v",
                         f"{shared_dir}:/.shared",
                         *starship_mount,
@@ -481,6 +487,12 @@ class TestStart:
                         AppEnvVars.ENV_TYPE,
                         "-e",
                         AppEnvVars.ENV_MANAGER,
+                        "-e",
+                        "AWS_PROFILE",
+                        "-e",
+                        "AWS_REGION",
+                        "-e",
+                        "AWS_DEFAULT_REGION",
                         "-v",
                         f"{shared_dir}:/.shared",
                         *starship_mount,
@@ -584,6 +596,12 @@ class TestStart:
                         AppEnvVars.ENV_TYPE,
                         "-e",
                         AppEnvVars.ENV_MANAGER,
+                        "-e",
+                        "AWS_PROFILE",
+                        "-e",
+                        "AWS_REGION",
+                        "-e",
+                        "AWS_DEFAULT_REGION",
                         "-v",
                         f"{shared_dir}:/.shared",
                         *starship_mount,
@@ -682,6 +700,12 @@ class TestStart:
                         AppEnvVars.ENV_TYPE,
                         "-e",
                         AppEnvVars.ENV_MANAGER,
+                        "-e",
+                        "AWS_PROFILE",
+                        "-e",
+                        "AWS_REGION",
+                        "-e",
+                        "AWS_DEFAULT_REGION",
                         "-v",
                         f"{shared_dir}:/.shared",
                         *starship_mount,
@@ -815,6 +839,12 @@ class TestStart:
                         AppEnvVars.ENV_TYPE,
                         "-e",
                         AppEnvVars.ENV_MANAGER,
+                        "-e",
+                        "AWS_PROFILE",
+                        "-e",
+                        "AWS_REGION",
+                        "-e",
+                        "AWS_DEFAULT_REGION",
                         "-v",
                         f"{shared_dir}:/.shared",
                         *starship_mount,
@@ -932,6 +962,12 @@ class TestStart:
                         AppEnvVars.ENV_TYPE,
                         "-e",
                         AppEnvVars.ENV_MANAGER,
+                        "-e",
+                        "AWS_PROFILE",
+                        "-e",
+                        "AWS_REGION",
+                        "-e",
+                        "AWS_DEFAULT_REGION",
                         "-v",
                         f"{shared_dir}:/.shared",
                         *starship_mount,
@@ -981,8 +1017,9 @@ class TestStart:
         )
 
         run_command = calls[0][0][0]
-        assert "AWS_PROFILE" not in run_command
+        # The ~/.aws mount is suppressed, but the non-secret AWS_* selectors are still forwarded.
         assert all("/home/dd/.aws" not in arg for arg in run_command)
+        assert "AWS_PROFILE" in run_command
 
 
 class TestStop:

--- a/tests/env/dev/types/test_linux_container.py
+++ b/tests/env/dev/types/test_linux_container.py
@@ -52,6 +52,25 @@ def get_starship_mount(global_shared_dir: Path) -> list[str]:
     return ["-v", f"{global_shared_dir / 'shell' / 'starship.toml'}:/.shared/shell/starship.toml"]
 
 
+def get_aws_mount(home_dir: str = "/home/dd") -> list[str]:
+    aws_dir = Path.home() / ".aws"
+    if not aws_dir.is_dir():
+        return []
+
+    from dda.utils.container.model import Mount
+
+    return [
+        "--mount",
+        Mount(type="bind", source=str(aws_dir), path=f"{home_dir}/.aws").as_csv(),
+        "-e",
+        "AWS_PROFILE",
+        "-e",
+        "AWS_REGION",
+        "-e",
+        "AWS_DEFAULT_REGION",
+    ]
+
+
 def get_volumes() -> list[str]:
     return [*get_data_volumes(), *get_cache_volumes()]
 
@@ -91,6 +110,7 @@ def test_default_config(app):
         "clone": False,
         "image": "datadog/agent-dev-env-linux",
         "no_pull": False,
+        "no_secrets": False,
         "repos": ["datadog-agent"],
         "shell": "zsh",
         "extra_volume_specs": [],
@@ -263,6 +283,7 @@ class TestStart:
                         "-v",
                         f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
                         *volumes,
+                        *get_aws_mount(),
                         "-v",
                         f"{repo_dir}:/repos/datadog-agent",
                         "datadog/agent-dev-env-linux",
@@ -357,6 +378,7 @@ class TestStart:
                         "-v",
                         f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
                         *volumes,
+                        *get_aws_mount(),
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
@@ -465,6 +487,7 @@ class TestStart:
                         "-v",
                         f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
                         *volumes,
+                        *get_aws_mount(),
                         "-v",
                         f"{repo_dir}:/repos/datadog-agent",
                         "datadog/agent-dev-env-linux",
@@ -567,6 +590,7 @@ class TestStart:
                         "-v",
                         f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
                         *volumes,
+                        *get_aws_mount(),
                         "-v",
                         f"{repo1_dir}:/repos/datadog-agent",
                         "-v",
@@ -664,6 +688,7 @@ class TestStart:
                         "-v",
                         f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
                         *volumes,
+                        *get_aws_mount(),
                         "datadog/agent-dev-env-linux",
                     ],
                 ),
@@ -796,6 +821,7 @@ class TestStart:
                         "-v",
                         f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
                         *volumes,
+                        *get_aws_mount(),
                         *[(x if x != "-v" else "--volume") for x in volume_specs],
                         "datadog/agent-dev-env-linux",
                     ],
@@ -912,6 +938,7 @@ class TestStart:
                         "-v",
                         f"{global_shared_dir / 'shell' / 'zsh' / '.zsh_history'}:/.shared/shell/zsh/.zsh_history",
                         *volumes,
+                        *get_aws_mount(),
                         *[(x if x != "-m" else "--mount") for x in mount_specs],
                         "datadog/agent-dev-env-linux",
                     ],
@@ -919,6 +946,43 @@ class TestStart:
                 {"encoding": "utf-8", "stdout": subprocess.PIPE, "stderr": subprocess.PIPE, "env": mocker.ANY},
             ),
         ]
+
+    def test_no_secrets(self, dda, helpers, mocker, temp_dir):
+        # `--no-secrets` prevents the container from receiving host credentials even when the host has `~/.aws`.
+        mocker.patch("dda.utils.ssh.write_server_config")
+        with (
+            temp_dir.as_cwd(),
+            helpers.hybrid_patch(
+                "subprocess.run",
+                return_values={
+                    # Start command checks the status
+                    1: CompletedProcess([], returncode=0, stdout="{}"),
+                    # Start method checks the status
+                    2: CompletedProcess([], returncode=0, stdout="{}"),
+                    # Capture container run
+                    # Readiness check
+                    4: CompletedProcess([], returncode=0, stdout="Server listening on :: port 22"),
+                    # Repo cloning
+                    5: CompletedProcess([], returncode=0, stdout="{}"),
+                },
+            ) as calls,
+        ):
+            result = dda("env", "dev", "start", "--no-pull", "--clone", "--no-secrets")
+
+        result.check(
+            exit_code=0,
+            output=helpers.dedent(
+                """
+                Creating and starting container: dda-linux-container-default
+                Waiting for container: dda-linux-container-default
+                Cloning repository: datadog-agent
+                """
+            ),
+        )
+
+        run_command = calls[0][0][0]
+        assert "AWS_PROFILE" not in run_command
+        assert all("/home/dd/.aws" not in arg for arg in run_command)
 
 
 class TestStop:


### PR DESCRIPTION
This makes it possible to authenticate from inside the developer environment.

```
❯ aws-vault exec ... -- aws s3 ls | lines | length
1171
❯ dda env dev run -- aws-vault exec ... -- aws s3 ls | lines | length
1171
```

Note that the native AWS CLI uses the `~/.aws` directory for caching so both the host and container share the same auth token. However, the `aws-vault` CLI does not since it uses a secret store like the system keyring. This is no different than a host-only setup e.g. running `aws-vault` after `aws sso login` would still trigger the OAuth flow.