### PR TITLE
Disable merge queue

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,0 +1,4 @@
+---
+schema-version: v1
+kind: mergequeue
+enable: false


### PR DESCRIPTION
## What does this PR do?

Disables the merge queue for this repository by adding `repository.datadog.yml` with only the merge queue block set to `enable: false`.

## Motivation

Requested as using the merge queue seems to hang: https://dd.slack.com/archives/C06PBHLD4DQ/p1785400603112769