### PR TITLE
[ACIX-1926] chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       run: dda run docs build
 
     - name: Check links
-      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
+      uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
       with:
         lycheeVersion: v0.23.0
         fail: true


### PR DESCRIPTION
Mechanical rewrite of every `uses:` reference to a full-length commit SHA, produced by [pinact](https://github.com/suzuki-shunsuke/pinact). An unpinned reference resolves to a mutable ref, so a compromise of the upstream action becomes code execution in this repository's CI.

The trailing `# vX.Y.Z` comment is what lets Renovate and Dependabot keep these bumped, so please keep it.

**One thing to check:** references that tracked `@main` or `@master` were resolved to the latest stable tag. If any of them floated deliberately and that behaviour was load-bearing here, say so on the PR and we will revert that line.
